### PR TITLE
Conditionally use GCR/ECR

### DIFF
--- a/main.go
+++ b/main.go
@@ -69,6 +69,12 @@ type controller struct {
 	kubeClient kubeInterface
 	ecrClient  ecrInterface
 	gcrClient  gcrInterface
+	config     providerConfig
+}
+
+type providerConfig struct {
+	ecrEnabled bool
+	gcrEnabled bool
 }
 
 type kubeInterface interface {
@@ -201,19 +207,31 @@ type SecretGenerator struct {
 	SecretName  string
 }
 
-func (c *controller) process() error {
-	secretGenerators := []SecretGenerator{
-		SecretGenerator{
+func getSecretGenerators(c *controller) []SecretGenerator {
+	secretGenerators := []SecretGenerator{}
+
+	if c.config.gcrEnabled {
+		secretGenerators = append(secretGenerators, SecretGenerator{
 			TokenGenFxn: c.getGCRAuthorizationKey,
 			IsJSONCfg:   false,
 			SecretName:  *argGCRSecretName,
-		},
-		SecretGenerator{
+		})
+	}
+
+	if c.config.ecrEnabled {
+		secretGenerators = append(secretGenerators, SecretGenerator{
 			TokenGenFxn: c.getECRAuthorizationKey,
 			IsJSONCfg:   true,
 			SecretName:  *argAWSSecretName,
-		},
+		})
 	}
+
+	return secretGenerators
+}
+
+func (c *controller) process() error {
+	secretGenerators := getSecretGenerators(c)
+
 	for _, secretGenerator := range secretGenerators {
 		newToken, err := secretGenerator.TokenGenFxn()
 		if err != nil {
@@ -283,10 +301,18 @@ func (c *controller) process() error {
 	return nil
 }
 
-func validateParams() {
+func validateParams() providerConfig {
+	var gcrEnabled bool
+	var ecrEnabled bool
+
 	awsAccountID = os.Getenv("awsaccount")
 	if len(awsAccountID) == 0 {
 		log.Print("Missing awsaccount env variable, assuming GCR usage")
+		gcrEnabled = true
+		ecrEnabled = false
+	} else {
+		gcrEnabled = false
+		ecrEnabled = true
 	}
 
 	awsRegionEnv := os.Getenv("awsregion")
@@ -294,13 +320,15 @@ func validateParams() {
 	if len(awsRegionEnv) > 0 {
 		argAWSRegion = &awsRegionEnv
 	}
+
+	return providerConfig{gcrEnabled, ecrEnabled}
 }
 
 func main() {
 	log.Print("Starting up...")
 	flags.Parse(os.Args)
 
-	validateParams()
+	config := validateParams()
 
 	log.Print("Using AWS Account: ", awsAccountID)
 	log.Printf("Using AWS Region: %s", *argAWSRegion)
@@ -309,7 +337,7 @@ func main() {
 	kubeClient := newKubeClient()
 	ecrClient := newEcrClient()
 	gcrClient := newGcrClient()
-	c := &controller{kubeClient, ecrClient, gcrClient}
+	c := &controller{kubeClient, ecrClient, gcrClient, config}
 
 	tick := time.Tick(time.Duration(*argRefreshMinutes) * time.Minute)
 

--- a/main.go
+++ b/main.go
@@ -321,7 +321,7 @@ func validateParams() providerConfig {
 		argAWSRegion = &awsRegionEnv
 	}
 
-	return providerConfig{gcrEnabled, ecrEnabled}
+	return providerConfig{ecrEnabled, gcrEnabled}
 }
 
 func main() {

--- a/main_test.go
+++ b/main_test.go
@@ -265,7 +265,8 @@ func TestgetECRAuthorizationKey(t *testing.T) {
 	kubeClient := newFakeKubeClient()
 	ecrClient := newFakeEcrClient()
 	gcrClient := newFakeGcrClient()
-	c := &controller{kubeClient, ecrClient, gcrClient}
+	testConfig := providerConfig{true, true}
+	c := &controller{kubeClient, ecrClient, gcrClient, testConfig}
 
 	token, err := c.getECRAuthorizationKey()
 
@@ -279,7 +280,8 @@ func TestProcessOnce(t *testing.T) {
 	ecrClient := newFakeEcrClient()
 	*argGCRURL = "fakeEndpoint"
 	gcrClient := newFakeGcrClient()
-	c := &controller{kubeClient, ecrClient, gcrClient}
+	testConfig := providerConfig{true, true}
+	c := &controller{kubeClient, ecrClient, gcrClient, testConfig}
 
 	err := c.process()
 	assert.Nil(t, err)
@@ -349,7 +351,8 @@ func TestProcessTwice(t *testing.T) {
 	ecrClient := newFakeEcrClient()
 	*argGCRURL = "fakeEndpoint"
 	gcrClient := newFakeGcrClient()
-	c := &controller{kubeClient, ecrClient, gcrClient}
+	testConfig := providerConfig{true, true}
+	c := &controller{kubeClient, ecrClient, gcrClient, testConfig}
 	err := c.process()
 	assert.Nil(t, err)
 	// test processing twice for idempotency
@@ -420,7 +423,8 @@ func TestProcessWithExistingSecrets(t *testing.T) {
 	ecrClient := newFakeEcrClient()
 	*argGCRURL = "fakeEndpoint"
 	gcrClient := newFakeGcrClient()
-	c := &controller{kubeClient, ecrClient, gcrClient}
+	testConfig := providerConfig{true, true}
+	c := &controller{kubeClient, ecrClient, gcrClient, testConfig}
 
 	secretGCR := &api.Secret{
 		ObjectMeta: api.ObjectMeta{
@@ -526,7 +530,8 @@ func TestProcessNoDefaultServiceAccount(t *testing.T) {
 	kubeClient := newFakeKubeClient()
 	ecrClient := newFakeEcrClient()
 	gcrClient := newFakeGcrClient()
-	c := &controller{kubeClient, ecrClient, gcrClient}
+	testConfig := providerConfig{true, true}
+	c := &controller{kubeClient, ecrClient, gcrClient, testConfig}
 
 	err := c.kubeClient.ServiceAccounts("namespace1").Delete("default")
 	assert.Nil(t, err)
@@ -541,7 +546,8 @@ func TestProcessWithExistingImagePullSecrets(t *testing.T) {
 	kubeClient := newFakeKubeClient()
 	ecrClient := newFakeEcrClient()
 	gcrClient := newFakeGcrClient()
-	c := &controller{kubeClient, ecrClient, gcrClient}
+	testConfig := providerConfig{true, true}
+	c := &controller{kubeClient, ecrClient, gcrClient, testConfig}
 
 	serviceAccount, err := c.kubeClient.ServiceAccounts("namespace1").Get("default")
 	assert.Nil(t, err)
@@ -588,7 +594,8 @@ func TestFailingGcrPassingEcrStillSucceeds(t *testing.T) {
 	kubeClient := newFakeKubeClient()
 	ecrClient := newFakeEcrClient()
 	gcrClient := newFakeFailingGcrClient()
-	c := &controller{kubeClient, ecrClient, gcrClient}
+	testConfig := providerConfig{true, false}
+	c := &controller{kubeClient, ecrClient, gcrClient, testConfig}
 
 	err := c.process()
 	assert.Nil(t, err)
@@ -598,7 +605,8 @@ func TestPassingGcrPassingEcrStillSucceeds(t *testing.T) {
 	kubeClient := newFakeKubeClient()
 	ecrClient := newFakeFailingEcrClient()
 	gcrClient := newFakeGcrClient()
-	c := &controller{kubeClient, ecrClient, gcrClient}
+	testConfig := providerConfig{false, true}
+	c := controller{kubeClient, ecrClient, gcrClient, testConfig}
 
 	err := c.process()
 	assert.Nil(t, err)

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"testing"
@@ -152,6 +153,12 @@ func (f *fakeEcrClient) GetAuthorizationToken(input *ecr.GetAuthorizationTokenIn
 	}, nil
 }
 
+type fakeFailingEcrClient struct{}
+
+func (f *fakeFailingEcrClient) GetAuthorizationToken(input *ecr.GetAuthorizationTokenInput) (*ecr.GetAuthorizationTokenOutput, error) {
+	return nil, errors.New("fake error")
+}
+
 type fakeGcrClient struct{}
 
 type fakeTokenSource struct{}
@@ -168,6 +175,12 @@ func newFakeTokenSource() fakeTokenSource {
 
 func (f *fakeGcrClient) DefaultTokenSource(ctx context.Context, scope ...string) (oauth2.TokenSource, error) {
 	return newFakeTokenSource(), nil
+}
+
+type fakeFailingGcrClient struct{}
+
+func (f *fakeFailingGcrClient) DefaultTokenSource(ctx context.Context, scope ...string) (oauth2.TokenSource, error) {
+	return nil, errors.New("fake error")
 }
 
 func newFakeKubeClient() *fakeKubeClient {
@@ -238,6 +251,14 @@ func newFakeEcrClient() *fakeEcrClient {
 
 func newFakeGcrClient() *fakeGcrClient {
 	return &fakeGcrClient{}
+}
+
+func newFakeFailingGcrClient() *fakeFailingGcrClient {
+	return &fakeFailingGcrClient{}
+}
+
+func newFakeFailingEcrClient() *fakeFailingEcrClient {
+	return &fakeFailingEcrClient{}
 }
 
 func TestgetECRAuthorizationKey(t *testing.T) {
@@ -561,4 +582,24 @@ func TestAwsRegionFromEnv(t *testing.T) {
 	validateParams()
 
 	assert.Equal(t, expectedRegion, *argAWSRegion)
+}
+
+func TestFailingGcrPassingEcrStillSucceeds(t *testing.T) {
+	kubeClient := newFakeKubeClient()
+	ecrClient := newFakeEcrClient()
+	gcrClient := newFakeFailingGcrClient()
+	c := &controller{kubeClient, ecrClient, gcrClient}
+
+	err := c.process()
+	assert.Nil(t, err)
+}
+
+func TestPassingGcrPassingEcrStillSucceeds(t *testing.T) {
+	kubeClient := newFakeKubeClient()
+	ecrClient := newFakeFailingEcrClient()
+	gcrClient := newFakeGcrClient()
+	c := &controller{kubeClient, ecrClient, gcrClient}
+
+	err := c.process()
+	assert.Nil(t, err)
 }


### PR DESCRIPTION
(a sketch for https://github.com/upmc-enterprises/registry-creds/issues/30)

This PR adds the concept of a `providerConfig` (to control whether we even *attempt* to fetch creds from each of ECR or GCR) to the `controller` so that we can conditionally include providers in `secretGenerators`. This implementation presupposes that a user would only want one or the other, which I think isn't the right assumption. I think maybe some additions to the args could help with that - I think I'm curious as to how one might detect whether it's reasonable to contact GCR (similar to the implication of providing `awsaccount` in the environment).

What do you think is best for those sorts of args?

The first commit (https://github.com/sophaskins/registry-creds/commit/24b1f5841c7ecec1469aa29f88ce917751a8c73e) demonstrates the bug I was experiencing in https://github.com/upmc-enterprises/registry-creds/issues/30