### PR TITLE
Added aws_assume_role

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The following parameters are driven via Environment variables.
   - AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY: Credentials to access AWS.
   - awsaccount: AWS Account Id.
   - awsregion: (optional) Can override the default AWS region by setting this variable.
+  - aws-assume-role (optional) can provide a role ARN that will be assumed for getting ECR authorization tokens
     > **Note:** The region can also be specified as an arg to the binary.  
 
 ## How to setup running in AWS

--- a/k8s/replicationController.yaml
+++ b/k8s/replicationController.yaml
@@ -41,6 +41,11 @@ spec:
               secretKeyRef:
                 name: registry-creds-ecr
                 key: aws-region
+          - name: aws_assume_role
+            valueFrom:
+              secretKeyRef:
+                name: registry-creds-ecr
+                key: aws_assume_role
           - name: DOCKER_PRIVATE_REGISTRY_PASSWORD
             valueFrom:
               secretKeyRef:

--- a/k8s/secret.yaml
+++ b/k8s/secret.yaml
@@ -29,6 +29,7 @@ data:
   AWS_SECRET_ACCESS_KEY: Y2hhbmdlbWU=
   aws-account: Y2hhbmdlbWU=
   aws-region: dXMtZWFzdC0x
+  aws_assume_role: YXJuOmF3czppYW06Ojk5OTk5OTk5OTpyb2xlL3JvbGUtYXJuLTIzNDIzNDIzZXRj
 type: Opaque
 
 ---


### PR DESCRIPTION
No additional testing :( , but haven't broken anything either.  Given the nature of the changes I'd want to mock out the AWS interface in order to test that the proper methods were called with the proper arguments.  

I'd be fine to do that, but there's no mocking lib in here already.  There's other ways as well, which I'd be happy to do but i'd prefer to get feedback before doing that as I hate wasting my time :)

In addition, I wasn't sure how to execute the binary against minikube.  If you had some guidance on how to develop this against minikube I'd be happy extend the documentation for you.  I did "test" this in that I isolated the code, but didn't go the full mile in terms of an actual fully operational test with kubernetes in the loop.  I just confirmed that when the correct credentials and env variables were available I'd get a token.  