### PR TITLE
Provide helper script to generate secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,31 @@ The following parameters are driven via Environment variables.
   - awsaccount: AWS Account Id.
   - awsregion: (optional) Can override the default AWS region by setting this variable.
   - aws-assume-role (optional) can provide a role ARN that will be assumed for getting ECR authorization tokens
-    > **Note:** The region can also be specified as an arg to the binary.  
+    > **Note:** The region can also be specified as an arg to the binary.
+
+## Setup Minikube
+
+```bash
+# Ensure the addon is enabled.
+minikube addons enable registry-creds
+
+# Generate the secret manifest and create the resources.
+cd contrib && ./generate-secrets.sh
+```
+
+To use the credentials, either patch the service account:
+```bash
+kubectl patch serviceaccount default -p '{"imagePullSecrets": [{"name": "awsecr-cred"}]}'
+```
+
+Or add in the `imagePullSecrets` section in your `deployment.yaml` file:
+```bash
+spec:
+  imagePullSecrets:
+  - name: awsecr-cred
+```
+
+See the last section of the [Configure Service Account](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/) documentation page for full reference.
 
 ## How to setup running in AWS
 
@@ -32,7 +56,7 @@ The following parameters are driven via Environment variables.
 2. Configure
 
    1. If running on AWS EC2, make sure your EC2 instances have the following IAM permissions:
-   
+
       ```json
       {
        "Effect": "Allow",
@@ -62,9 +86,9 @@ The following parameters are driven via Environment variables.
    ```bash
    kubectl create -f k8s/replicationController.yaml
    ```
-   
+
    > **NOTE:** If running on premise, no need to provide `AWS_ACCESS_KEY_ID` or `AWS_SECRET_ACCESS_KEY` since that will come from the EC2 instance.
-   
+
 4. Use `awsecr-cred` for name of `imagePullSecrets` on your `deployment.yaml` file.
 
 ## How to setup running in GCR
@@ -89,7 +113,7 @@ The value for `application_default_credentials.json` can be obtained with the fo
    ```bash
    kubectl create -f k8s/replicationController.yaml
    ```
-   
+
 ## How to setup running in Docker Private Registry
 
 1. Clone the repo and navigate to directory

--- a/contrib/generate-secrets.sh
+++ b/contrib/generate-secrets.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+set -euo pipefail
+
+# Retrieve private docker registry data from the AWS cli.
+AWS_ECR_LOGIN_CMD=$(aws ecr get-login)
+AWS_ECR_USER=$(echo "${AWS_ECR_LOGIN_CMD}"| cut -d ' ' -f4 | tr -d '\n' | base64 )
+AWS_ECR_PASSWORD=$(echo "${AWS_ECR_LOGIN_CMD}"| cut -d ' ' -f6 | tr -d '\n' | base64 )
+AWS_ECR_EMAIL=$(echo "${AWS_ECR_LOGIN_CMD}"| cut -d ' ' -f8 | tr -d '\n' | base64 )
+AWS_ECR_SERVER=$(echo "${AWS_ECR_LOGIN_CMD}"| cut -d ' ' -f9 | tr -d '\n' | base64 )
+
+# Retrieve AWS access from the AWS cli.
+AWS_ACCESS_KEY_BASE64=$(aws configure get default.aws_access_key_id | tr -d '\n'| base64 )
+AWS_SECRET_KEY_BASE64=$(aws configure get default.aws_secret_access_key | tr -d '\n' | base64 )
+AWS_REGION_BASE64=$(aws configure get region | tr -d '\n' | base64 )
+AWS_ACCOUNT_ID_BASE64=$(aws iam get-user | grep arn:aws | cut -d':' -f6 | tr -d '\n' | base64 )
+
+# Retrieve GCloud credentials from default configuration.
+GCLOUD_DEFAULT_CREDS_FILE="${HOME}/.config/gcloud/application_default_credentials.json"
+if [ -f  "${GCLOUD_DEFAULT_CREDS_FILE}" ]; then
+  GCLOUD_DEFAULT_CREDS_BASE64=$(base64 "${GCLOUD_DEFAULT_CREDS_FILE}")
+else
+  GCLOUD_DEFAULT_CREDS_BASE64="Y2hhbmdlbWU="
+fi
+
+# Generate the secrets file.
+cat > secret.yaml  <<EOF
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: registry-creds-dpr
+  namespace: kube-system
+  labels:
+    app: registry-creds
+    kubernetes.io/minikube-addons: registry-creds
+    cloud: private
+data:
+  DOCKER_PRIVATE_REGISTRY_SERVER: "${AWS_ECR_SERVER}"
+  DOCKER_PRIVATE_REGISTRY_USER: "${AWS_ECR_USER}"
+  DOCKER_PRIVATE_REGISTRY_PASSWORD: "${AWS_ECR_PASSWORD}"
+type: Opaque
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: registry-creds-ecr
+  namespace: kube-system
+  labels:
+    app: registry-creds
+    kubernetes.io/minikube-addons: registry-creds
+    cloud: ecr
+data:
+  AWS_ACCESS_KEY_ID: "${AWS_ACCESS_KEY_BASE64}"
+  AWS_SECRET_ACCESS_KEY: "${AWS_SECRET_KEY_BASE64}"
+  aws-region: "${AWS_REGION_BASE64}"
+  aws-account: "${AWS_ACCOUNT_ID_BASE64}"
+  aws-assume-role: ""
+  AWS_SESSION_TOKEN: ""
+type: Opaque
+---
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: registry-creds-gcr
+  namespace: kube-system
+  labels:
+    app: registry-creds
+    kubernetes.io/minikube-addons: registry-creds
+    cloud: gcr
+data:
+  application_default_credentials.json: "${GCLOUD_DEFAULT_CREDS_BASE64}"
+  gcrurl: aHR0cHM6Ly9nY3IuaW8=
+type: Opaque
+EOF
+
+# Create the Kubernetes objects.
+kubectl apply -f secret.yaml
+
+# Clean up.
+rm -f secret.yaml

--- a/k8s/secret.yaml
+++ b/k8s/secret.yaml
@@ -45,4 +45,5 @@ metadata:
     cloud: gcr
 data:
   application_default_credentials.json: Y2hhbmdlbWU=
+  gcrurl: aHR0cHM6Ly9nY3IuaW8=
 type: Opaque


### PR DESCRIPTION
This patch provides a helper script to generate secrets from the AWS cli
and from the default Gloud credential file.

The `README.md` file was updated to provide instructions to setup minikube.

Drive-by:
* Fix missing `gcurl` value in the secret template file.