### PR TITLE
Support logging in to muliple AWS accounts ECR's

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The following parameters are driven via Environment variables.
 
 - Environment Variables:
   - AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY: Credentials to access AWS.
-  - awsaccount: AWS Account Id.
+  - awsaccount: Comma separated list of AWS Account Ids.
   - awsregion: (optional) Can override the default AWS region by setting this variable.
   - aws-assume-role (optional) can provide a role ARN that will be assumed for getting ECR authorization tokens
     > **Note:** The region can also be specified as an arg to the binary.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The following parameters are driven via Environment variables.
   - awsaccount: AWS Account Id.
   - awsregion: (optional) Can override the default AWS region by setting this variable.
   - aws-assume-role (optional) can provide a role ARN that will be assumed for getting ECR authorization tokens
-    > **Note:** The region can also be specified as an arg to the binary.  
+    > **Note:** The region can also be specified as an arg to the binary.
 
 ## How to setup running in AWS
 
@@ -32,7 +32,7 @@ The following parameters are driven via Environment variables.
 2. Configure
 
    1. If running on AWS EC2, make sure your EC2 instances have the following IAM permissions:
-   
+
       ```json
       {
        "Effect": "Allow",
@@ -62,9 +62,9 @@ The following parameters are driven via Environment variables.
    ```bash
    kubectl create -f k8s/replicationController.yaml
    ```
-   
+
    > **NOTE:** If running on premise, no need to provide `AWS_ACCESS_KEY_ID` or `AWS_SECRET_ACCESS_KEY` since that will come from the EC2 instance.
-   
+
 4. Use `awsecr-cred` for name of `imagePullSecrets` on your `deployment.yaml` file.
 
 ## How to setup running in GCR
@@ -89,7 +89,7 @@ The value for `application_default_credentials.json` can be obtained with the fo
    ```bash
    kubectl create -f k8s/replicationController.yaml
    ```
-   
+
 ## How to setup running in Docker Private Registry
 
 1. Clone the repo and navigate to directory

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ package main
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"log"
 	"os"
@@ -47,7 +48,6 @@ import (
 
 const (
 	dockerCfgTemplate                = `{"%s":{"username":"oauth2accesstoken","password":"%s","email":"none"}}`
-	dockerJSONTemplate               = `{"auths":{"%s":{"auth":"%s","email":"none"}}}`
 	dockerPrivateRegistryPasswordKey = "DOCKER_PRIVATE_REGISTRY_PASSWORD"
 	dockerPrivateRegistryServerKey   = "DOCKER_PRIVATE_REGISTRY_SERVER"
 	dockerPrivateRegistryUserKey     = "DOCKER_PRIVATE_REGISTRY_USER"
@@ -71,8 +71,17 @@ var (
 )
 
 var (
-	awsAccountID string
+	awsAccountIDs []string
 )
+
+type dockerJSON struct {
+	Auths map[string]registryAuth `json:"auths,omitempty"`
+}
+
+type registryAuth struct {
+	Auth  string `json:"auth"`
+	Email string `json:"email"`
+}
 
 type controller struct {
 	k8sutil   *k8sutil.K8sutilInterface
@@ -140,39 +149,49 @@ func newGcrClient() gcrInterface {
 	return gcrClient{}
 }
 
-func (c *controller) getDPRToken() (AuthToken, error) {
-	return c.dprClient.getAuthToken(*argDPRServer, *argDPRUser, *argDPRPassword)
+func (c *controller) getDPRToken() ([]AuthToken, error) {
+	token, err := c.dprClient.getAuthToken(*argDPRServer, *argDPRUser, *argDPRPassword)
+	return []AuthToken{token}, err
 }
 
-func (c *controller) getGCRAuthorizationKey() (AuthToken, error) {
+func (c *controller) getGCRAuthorizationKey() ([]AuthToken, error) {
 	ts, err := c.gcrClient.DefaultTokenSource(context.TODO(), "https://www.googleapis.com/auth/cloud-platform")
 	if err != nil {
-		return AuthToken{}, err
+		return []AuthToken{}, err
 	}
 
 	token, err := ts.Token()
 	if err != nil {
-		return AuthToken{}, err
+		return []AuthToken{}, err
 	}
 
 	if !token.Valid() {
-		return AuthToken{}, fmt.Errorf("token was invalid")
+		return []AuthToken{}, fmt.Errorf("token was invalid")
 	}
 
 	if token.Type() != "Bearer" {
-		return AuthToken{}, fmt.Errorf(fmt.Sprintf("expected token type \"Bearer\" but got \"%s\"", token.Type()))
+		return []AuthToken{}, fmt.Errorf(fmt.Sprintf("expected token type \"Bearer\" but got \"%s\"", token.Type()))
 	}
 
-	return AuthToken{
-		AccessToken: token.AccessToken,
-		Endpoint:    *argGCRURL}, nil
+	return []AuthToken{
+		AuthToken{
+			AccessToken: token.AccessToken,
+			Endpoint:    *argGCRURL},
+	}, nil
 }
 
-func (c *controller) getECRAuthorizationKey() (AuthToken, error) {
+func (c *controller) getECRAuthorizationKey() ([]AuthToken, error) {
+
+	var tokens []AuthToken
+	var regIds []*string
+	regIds = make([]*string, len(awsAccountIDs))
+
+	for i, awsAccountID := range awsAccountIDs {
+		regIds[i] = aws.String(awsAccountID)
+	}
+
 	params := &ecr.GetAuthorizationTokenInput{
-		RegistryIds: []*string{
-			aws.String(awsAccountID),
-		},
+		RegistryIds: regIds,
 	}
 
 	resp, err := c.ecrClient.GetAuthorizationToken(params)
@@ -181,32 +200,47 @@ func (c *controller) getECRAuthorizationKey() (AuthToken, error) {
 		// Print the error, cast err to awserr.Error to get the Code and
 		// Message from an error.
 		logrus.Println(err.Error())
-		return AuthToken{}, err
+		return []AuthToken{}, err
 	}
 
-	token := resp.AuthorizationData[0]
+	for _, auth := range resp.AuthorizationData {
+		tokens = append(tokens, AuthToken{
+			AccessToken: *auth.AuthorizationToken,
+			Endpoint:    *auth.ProxyEndpoint,
+		})
 
-	return AuthToken{
-		AccessToken: *token.AuthorizationToken,
-		Endpoint:    *token.ProxyEndpoint}, err
+	}
+	return tokens, nil
 }
 
-func generateSecretObj(token string, endpoint string, isJSONCfg bool, secretName string) *v1.Secret {
+func generateSecretObj(tokens []AuthToken, isJSONCfg bool, secretName string) (*v1.Secret, error) {
 	secret := &v1.Secret{
 		ObjectMeta: v1.ObjectMeta{
 			Name: secretName,
 		},
 	}
 	if isJSONCfg {
-		secret.Data = map[string][]byte{
-			".dockerconfigjson": []byte(fmt.Sprintf(dockerJSONTemplate, endpoint, token))}
+		auths := map[string]registryAuth{}
+		for _, token := range tokens {
+			auths[token.Endpoint] = registryAuth{
+				Auth:  token.AccessToken,
+				Email: "none",
+			}
+		}
+		configJSON, err := json.Marshal(dockerJSON{Auths: auths})
+		if err != nil {
+			return secret, nil
+		}
+		secret.Data = map[string][]byte{".dockerconfigjson": configJSON}
 		secret.Type = "kubernetes.io/dockerconfigjson"
 	} else {
-		secret.Data = map[string][]byte{
-			".dockercfg": []byte(fmt.Sprintf(dockerCfgTemplate, endpoint, token))}
-		secret.Type = "kubernetes.io/dockercfg"
+		if len(tokens) == 1 {
+			secret.Data = map[string][]byte{
+				".dockercfg": []byte(fmt.Sprintf(dockerCfgTemplate, tokens[0].Endpoint, tokens[0].AccessToken))}
+			secret.Type = "kubernetes.io/dockercfg"
+		}
 	}
-	return secret
+	return secret, nil
 }
 
 type AuthToken struct {
@@ -215,7 +249,7 @@ type AuthToken struct {
 }
 
 type SecretGenerator struct {
-	TokenGenFxn func() (AuthToken, error)
+	TokenGenFxn func() ([]AuthToken, error)
 	IsJSONCfg   bool
 	SecretName  string
 }
@@ -298,13 +332,17 @@ func (c *controller) generateSecrets() []*v1.Secret {
 	for _, secretGenerator := range secretGenerators {
 		logrus.Printf("------------------ [%s] ----------------------\n", secretGenerator.SecretName)
 
-		newToken, err := secretGenerator.TokenGenFxn()
+		newTokens, err := secretGenerator.TokenGenFxn()
 		if err != nil {
 			logrus.Printf("Error getting secret for provider %s. Skipping secret provider! [Err: %s]", secretGenerator.SecretName, err)
 			continue
 		}
-		newSecret := generateSecretObj(newToken.AccessToken, newToken.Endpoint, secretGenerator.IsJSONCfg, secretGenerator.SecretName)
-		secrets = append(secrets, newSecret)
+		newSecret, err := generateSecretObj(newTokens, secretGenerator.IsJSONCfg, secretGenerator.SecretName)
+		if err != nil {
+			logrus.Printf("Error generating secret for provider %s. Skipping secret provider! [Err: %s]", secretGenerator.SecretName, err)
+		} else {
+			secrets = append(secrets, newSecret)
+		}
 	}
 	return secrets
 }
@@ -324,7 +362,9 @@ func validateParams() {
 	}
 
 	if len(awsAccountIDEnv) > 0 {
-		awsAccountID = awsAccountIDEnv
+		awsAccountIDs = strings.Split(awsAccountIDEnv, ",")
+	} else {
+		awsAccountIDs = []string{""}
 	}
 
 	if len(dprPassword) > 0 {
@@ -371,7 +411,7 @@ func main() {
 
 	validateParams()
 
-	log.Print("Using AWS Account: ", awsAccountID)
+	log.Print("Using AWS Account: ", strings.Join(awsAccountIDs, ","))
 	log.Print("Using AWS Region: ", *argAWSRegion)
 	log.Print("Using AWS Assume Role: ", *argAWSAssumeRole)
 	log.Print("Refresh Interval (minutes): ", *argRefreshMinutes)

--- a/main.go
+++ b/main.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ecr"
 	flag "github.com/spf13/pflag"
@@ -42,7 +43,6 @@ import (
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	"k8s.io/client-go/pkg/api/v1"
-	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 )
 
 const (
@@ -67,7 +67,7 @@ var (
 	argDPRUser        = flags.String("dpr-user", "", "Docker Private Registry user")
 	argRefreshMinutes = flags.Int("refresh-mins", 60, `Default time to wait before refreshing (60 minutes)`)
 	argSkipKubeSystem = flags.Bool("skip-kube-system", true, `If true, will not attempt to set ImagePullSecrets on the kube-system namespace`)
-	argAWSAssumeRole  = flags.String( "aws_assume_role", "",  `If specified AWS will assume this role and use it to retrieve tokens`)
+	argAWSAssumeRole  = flags.String("aws_assume_role", "", `If specified AWS will assume this role and use it to retrieve tokens`)
 )
 
 var (
@@ -313,7 +313,7 @@ func validateParams() {
 	// Allow environment variables to overwrite args
 	awsAccountIDEnv := os.Getenv("awsaccount")
 	awsRegionEnv := os.Getenv("awsregion")
-	argAWSAssumeRoleEnv := os.Getenv( "aws_assume_role")
+	argAWSAssumeRoleEnv := os.Getenv("aws_assume_role")
 	dprPassword := os.Getenv(dockerPrivateRegistryPasswordKey)
 	dprServer := os.Getenv(dockerPrivateRegistryServerKey)
 	dprUser := os.Getenv(dockerPrivateRegistryUserKey)

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -179,6 +180,20 @@ func (f *fakeNamespaces) Status(item *v1.Namespace) (*v1.Namespace, error) { ret
 type fakeEcrClient struct{}
 
 func (f *fakeEcrClient) GetAuthorizationToken(input *ecr.GetAuthorizationTokenInput) (*ecr.GetAuthorizationTokenOutput, error) {
+	if len(input.RegistryIds) == 2 {
+		return &ecr.GetAuthorizationTokenOutput{
+			AuthorizationData: []*ecr.AuthorizationData{
+				&ecr.AuthorizationData{
+					AuthorizationToken: aws.String("fakeToken1"),
+					ProxyEndpoint:      aws.String("fakeEndpoint1"),
+				},
+				&ecr.AuthorizationData{
+					AuthorizationToken: aws.String("fakeToken2"),
+					ProxyEndpoint:      aws.String("fakeEndpoint2"),
+				},
+			},
+		}, nil
+	}
 	return &ecr.GetAuthorizationTokenOutput{
 		AuthorizationData: []*ecr.AuthorizationData{
 			&ecr.AuthorizationData{
@@ -337,13 +352,25 @@ func TestGetECRAuthorizationKey(t *testing.T) {
 	ecrClient := newFakeEcrClient()
 	gcrClient := newFakeGcrClient()
 	dprClient := newFakeDprClient()
+	awsAccountIDs = []string{"12345678", "999999"}
 	c := &controller{util, ecrClient, gcrClient, dprClient}
 
-	token, err := c.getECRAuthorizationKey()
+	tokens, err := c.getECRAuthorizationKey()
 
-	assert.Equal(t, "fakeToken", token.AccessToken)
-	assert.Equal(t, "fakeEndpoint", token.Endpoint)
 	assert.Nil(t, err)
+	assert.Equal(t, 2, len(tokens))
+	assert.Equal(t, "fakeToken1", tokens[0].AccessToken)
+	assert.Equal(t, "fakeEndpoint1", tokens[0].Endpoint)
+	assert.Equal(t, "fakeToken2", tokens[1].AccessToken)
+	assert.Equal(t, "fakeEndpoint2", tokens[1].Endpoint)
+}
+
+func assertDockerJSONContains(t *testing.T, endpoint, token string, secret *v1.Secret) {
+	d := dockerJSON{}
+	assert.Nil(t, json.Unmarshal(secret.Data[".dockerconfigjson"], &d))
+	assert.Contains(t, d.Auths, endpoint)
+	assert.Equal(t, d.Auths[endpoint].Auth, token)
+	assert.Equal(t, d.Auths[endpoint].Email, "none")
 }
 
 func TestProcessOnce(t *testing.T) {
@@ -353,6 +380,7 @@ func TestProcessOnce(t *testing.T) {
 	*argGCRURL = "fakeEndpoint"
 	gcrClient := newFakeGcrClient()
 	dprClient := newFakeDprClient()
+	awsAccountIDs = []string{""}
 	c := &controller{util, ecrClient, gcrClient, dprClient}
 
 	process(t, c)
@@ -386,20 +414,16 @@ func TestProcessOnce(t *testing.T) {
 	assert.Equal(t, *argGCRSecretName, serviceAccount.ImagePullSecrets[0].Name)
 
 	// Test AWS
-	secret, err = c.k8sutil.GetSecret("namespace2", *argAWSSecretName)
+	secret, err = c.k8sutil.GetSecret("namespace1", *argAWSSecretName)
 	assert.Nil(t, err)
 	assert.Equal(t, *argAWSSecretName, secret.Name)
-	assert.Equal(t, map[string][]byte{
-		".dockerconfigjson": []byte(fmt.Sprintf(dockerJSONTemplate, "fakeEndpoint", "fakeToken")),
-	}, secret.Data)
-	assert.Equal(t, v1.SecretType("kubernetes.io/dockerconfigjson"), secret.Type)
+	assertDockerJSONContains(t, "fakeEndpoint", "fakeToken", secret)
 
+	assert.Equal(t, v1.SecretType("kubernetes.io/dockerconfigjson"), secret.Type)
 	secret, err = c.k8sutil.GetSecret("namespace2", *argAWSSecretName)
 	assert.Nil(t, err)
 	assert.Equal(t, *argAWSSecretName, secret.Name)
-	assert.Equal(t, map[string][]byte{
-		".dockerconfigjson": []byte(fmt.Sprintf(dockerJSONTemplate, "fakeEndpoint", "fakeToken")),
-	}, secret.Data)
+	assertDockerJSONContains(t, "fakeEndpoint", "fakeToken", secret)
 	assert.Equal(t, v1.SecretType("kubernetes.io/dockerconfigjson"), secret.Type)
 
 	_, err = c.k8sutil.GetSecret("kube-system", *argAWSSecretName)
@@ -460,17 +484,13 @@ func TestProcessTwice(t *testing.T) {
 	secret, err = c.k8sutil.GetSecret("namespace2", *argAWSSecretName)
 	assert.Nil(t, err)
 	assert.Equal(t, *argAWSSecretName, secret.Name)
-	assert.Equal(t, map[string][]byte{
-		".dockerconfigjson": []byte(fmt.Sprintf(dockerJSONTemplate, "fakeEndpoint", "fakeToken")),
-	}, secret.Data)
+	assertDockerJSONContains(t, "fakeEndpoint", "fakeToken", secret)
 	assert.Equal(t, v1.SecretType("kubernetes.io/dockerconfigjson"), secret.Type)
 
 	secret, err = c.k8sutil.GetSecret("namespace2", *argAWSSecretName)
 	assert.Nil(t, err)
 	assert.Equal(t, *argAWSSecretName, secret.Name)
-	assert.Equal(t, map[string][]byte{
-		".dockerconfigjson": []byte(fmt.Sprintf(dockerJSONTemplate, "fakeEndpoint", "fakeToken")),
-	}, secret.Data)
+	assertDockerJSONContains(t, "fakeEndpoint", "fakeToken", secret)
 	assert.Equal(t, v1.SecretType("kubernetes.io/dockerconfigjson"), secret.Type)
 
 	_, err = c.k8sutil.GetSecret("kube-system", *argAWSSecretName)
@@ -579,50 +599,38 @@ func TestProcessWithExistingSecrets(t *testing.T) {
 	secretAWS, err = c.k8sutil.GetSecret("namespace1", *argAWSSecretName)
 	assert.Nil(t, err)
 	assert.Equal(t, *argAWSSecretName, secretAWS.Name)
-	assert.Equal(t, map[string][]byte{
-		".dockerconfigjson": []byte(fmt.Sprintf(dockerJSONTemplate, "fakeEndpoint", "fakeToken")),
-	}, secretAWS.Data)
+	assertDockerJSONContains(t, "fakeEndpoint", "fakeToken", secretAWS)
 	assert.Equal(t, secretAWS.Type, v1.SecretType("kubernetes.io/dockerconfigjson"))
 
 	secretAWS, err = c.k8sutil.GetSecret("namespace2", *argAWSSecretName)
 	assert.Nil(t, err)
 	assert.Equal(t, *argAWSSecretName, secretAWS.Name)
-	assert.Equal(t, map[string][]byte{
-		".dockerconfigjson": []byte(fmt.Sprintf(dockerJSONTemplate, "fakeEndpoint", "fakeToken")),
-	}, secretAWS.Data)
+	assertDockerJSONContains(t, "fakeEndpoint", "fakeToken", secretAWS)
 	assert.Equal(t, v1.SecretType("kubernetes.io/dockerconfigjson"), secretAWS.Type)
 
 	secretAWS, err = c.k8sutil.GetSecret("namespace1", *argAWSSecretName)
 	assert.Nil(t, err)
 	assert.Equal(t, *argAWSSecretName, secretAWS.Name)
-	assert.Equal(t, map[string][]byte{
-		".dockerconfigjson": []byte(fmt.Sprintf(dockerJSONTemplate, "fakeEndpoint", "fakeToken")),
-	}, secretAWS.Data)
+	assertDockerJSONContains(t, "fakeEndpoint", "fakeToken", secretAWS)
 	assert.Equal(t, secretAWS.Type, v1.SecretType("kubernetes.io/dockerconfigjson"))
 
 	secretAWS, err = c.k8sutil.GetSecret("namespace2", *argAWSSecretName)
 	assert.Nil(t, err)
 	assert.Equal(t, *argAWSSecretName, secretAWS.Name)
-	assert.Equal(t, map[string][]byte{
-		".dockerconfigjson": []byte(fmt.Sprintf(dockerJSONTemplate, "fakeEndpoint", "fakeToken")),
-	}, secretAWS.Data)
+	assertDockerJSONContains(t, "fakeEndpoint", "fakeToken", secretAWS)
 	assert.Equal(t, v1.SecretType("kubernetes.io/dockerconfigjson"), secretAWS.Type)
 
 	// Test Private Docker Registry
 	secretDPR, err = c.k8sutil.GetSecret("namespace1", *argDPRSecretName)
 	assert.Nil(t, err)
 	assert.Equal(t, *argDPRSecretName, secretDPR.Name)
-	assert.Equal(t, map[string][]byte{
-		".dockerconfigjson": []byte(fmt.Sprintf(dockerJSONTemplate, "fakeEndpoint", "fakeToken")),
-	}, secretDPR.Data)
+	assertDockerJSONContains(t, "fakeEndpoint", "fakeToken", secretDPR)
 	assert.Equal(t, v1.SecretType("kubernetes.io/dockerconfigjson"), secretDPR.Type)
 
 	secretDPR, err = c.k8sutil.GetSecret("namespace2", *argDPRSecretName)
 	assert.Nil(t, err)
 	assert.Equal(t, *argDPRSecretName, secretDPR.Name)
-	assert.Equal(t, map[string][]byte{
-		".dockerconfigjson": []byte(fmt.Sprintf(dockerJSONTemplate, "fakeEndpoint", "fakeToken")),
-	}, secretDPR.Data)
+	assertDockerJSONContains(t, "fakeEndpoint", "fakeToken", secretDPR)
 	assert.Equal(t, v1.SecretType("kubernetes.io/dockerconfigjson"), secretDPR.Type)
 }
 
@@ -704,6 +712,7 @@ func TestFailingGcrPassingEcrStillSucceeds(t *testing.T) {
 	ecrClient := newFakeEcrClient()
 	gcrClient := newFakeFailingGcrClient()
 	dprClient := newFakeFailingDprClient()
+	awsAccountIDs = []string{""}
 	c := &controller{util, ecrClient, gcrClient, dprClient}
 
 	process(t, c)
@@ -714,6 +723,7 @@ func TestPassingGcrPassingEcrStillSucceeds(t *testing.T) {
 	ecrClient := newFakeFailingEcrClient()
 	gcrClient := newFakeGcrClient()
 	dprClient := newFakeFailingDprClient()
+	awsAccountIDs = []string{""}
 	c := controller{util, ecrClient, gcrClient, dprClient}
 
 	process(t, &c)

--- a/main_test.go
+++ b/main_test.go
@@ -227,7 +227,7 @@ func (f *fakeDprClient) getAuthToken(server, user, password string) (AuthToken, 
 
 type fakeFailingDprClient struct{}
 
-func (f *fakeFailingDprClient) getAuthToken(server, user, password string) (AuthToken, error){
+func (f *fakeFailingDprClient) getAuthToken(server, user, password string) (AuthToken, error) {
 	return AuthToken{}, errors.New("fake error")
 }
 


### PR DESCRIPTION
Environment variable `awsaccount` now takes a comma separated list of accounts to get credentials. This allows a user with cross account access to login to multiple ECR's.
