### PR TITLE
Add AWS_SESSION_TOKEN with empty value in secrets

### DIFF
--- a/k8s/secret.yaml
+++ b/k8s/secret.yaml
@@ -30,6 +30,8 @@ data:
   aws-account: Y2hhbmdlbWU=
   aws-region: dXMtZWFzdC0x
   aws_assume_role: YXJuOmF3czppYW06Ojk5OTk5OTk5OTpyb2xlL3JvbGUtYXJuLTIzNDIzNDIzZXRj
+  # AWS_SESSION_TOKEN is optional. If you do not use it just provide an empty value:
+  AWS_SESSION_TOKEN: ""
 type: Opaque
 
 ---


### PR DESCRIPTION
If you do not provide the AWS_SESSION_TOKEN the Replication Controller will fail.