### PR TITLE
Fix aws-assume-role reference

### DIFF
--- a/k8s/replicationController.yaml
+++ b/k8s/replicationController.yaml
@@ -45,7 +45,7 @@ spec:
             valueFrom:
               secretKeyRef:
                 name: registry-creds-ecr
-                key: aws_assume_role
+                key: aws-assume-role
           - name: DOCKER_PRIVATE_REGISTRY_PASSWORD
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
Currently the pod fails to launch because it tries to find a `aws_assume_role` secret:

```
  Warning  Failed       2m (x4 over 3m)          kubelet, node3     Error: Couldn't find key aws_assume_role in Secret kube-system/registry-creds-ecr
```

The secret name is spelled with dashes instead of underscores. This PR updated the rc spec to use the right spelling.