### PR TITLE
Retry mechanism for token generation failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ The following parameters are driven via Environment variables.
   - awsregion: (optional) Can override the default AWS region by setting this variable.
   - aws-assume-role (optional) can provide a role ARN that will be assumed for getting ECR authorization tokens
     > **Note:** The region can also be specified as an arg to the binary.
+  - TOKEN_RETRY_TYPE: The type of Timer to use when getting a registry token fails and must be retried; "simple" or "exponential" (default: simple)
   - TOKEN_RETRIES: The number of times to retry getting a registry token if an error occurred (default: 3)
-  - TOKEN_RETRY_DELAY: The number of seconds to delay between successive retries at getting a registry token (default: 5)
+  - TOKEN_RETRY_DELAY: The number of seconds to delay between successive retries at getting a registry token; applies to "simple" retry timer only (default: 5)
 
 ## How to setup running in AWS
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ The following parameters are driven via Environment variables.
   - awsregion: (optional) Can override the default AWS region by setting this variable.
   - aws-assume-role (optional) can provide a role ARN that will be assumed for getting ECR authorization tokens
     > **Note:** The region can also be specified as an arg to the binary.
+  - TOKEN_RETRIES: The number of times to retry getting a registry token if an error occurred (default: 3)
+  - TOKEN_RETRY_DELAY: The number of seconds to delay between successive retries at getting a registry token (default: 5)
 
 ## How to setup running in AWS
 

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -51,27 +52,36 @@ const (
 	dockerPrivateRegistryPasswordKey = "DOCKER_PRIVATE_REGISTRY_PASSWORD"
 	dockerPrivateRegistryServerKey   = "DOCKER_PRIVATE_REGISTRY_SERVER"
 	dockerPrivateRegistryUserKey     = "DOCKER_PRIVATE_REGISTRY_USER"
+	tokenGenRetriesKey               = "TOKEN_RETRIES"
+	tokenGenRetryDelayKey            = "TOKEN_RETRY_DELAY"
+	defaultTokenGenRetries           = 3
+	defaultTokenGenRetryDelay        = 5 // in seconds
 )
 
 var (
-	flags             = flag.NewFlagSet("", flag.ContinueOnError)
-	argKubecfgFile    = flags.String("kubecfg-file", "", `Location of kubecfg file for access to kubernetes master service; --kube_master_url overrides the URL part of this; if neither this nor --kube_master_url are provided, defaults to service account tokens`)
-	argKubeMasterURL  = flags.String("kube-master-url", "", `URL to reach kubernetes master. Env variables in this flag will be expanded.`)
-	argAWSSecretName  = flags.String("aws-secret-name", "awsecr-cred", `Default AWS secret name`)
-	argDPRSecretName  = flags.String("dpr-secret-name", "dpr-secret", `Default Docker Private Registry secret name`)
-	argGCRSecretName  = flags.String("gcr-secret-name", "gcr-secret", `Default GCR secret name`)
-	argGCRURL         = flags.String("gcr-url", "https://gcr.io", `Default GCR URL`)
-	argAWSRegion      = flags.String("aws-region", "us-east-1", `Default AWS region`)
-	argDPRPassword    = flags.String("dpr-password", "", "Docker Private Registry password")
-	argDPRServer      = flags.String("dpr-server", "", "Docker Private Registry server")
-	argDPRUser        = flags.String("dpr-user", "", "Docker Private Registry user")
-	argRefreshMinutes = flags.Int("refresh-mins", 60, `Default time to wait before refreshing (60 minutes)`)
-	argSkipKubeSystem = flags.Bool("skip-kube-system", true, `If true, will not attempt to set ImagePullSecrets on the kube-system namespace`)
-	argAWSAssumeRole  = flags.String("aws_assume_role", "", `If specified AWS will assume this role and use it to retrieve tokens`)
+	flags                    = flag.NewFlagSet("", flag.ContinueOnError)
+	argKubecfgFile           = flags.String("kubecfg-file", "", `Location of kubecfg file for access to kubernetes master service; --kube_master_url overrides the URL part of this; if neither this nor --kube_master_url are provided, defaults to service account tokens`)
+	argKubeMasterURL         = flags.String("kube-master-url", "", `URL to reach kubernetes master. Env variables in this flag will be expanded.`)
+	argAWSSecretName         = flags.String("aws-secret-name", "awsecr-cred", `Default AWS secret name`)
+	argDPRSecretName         = flags.String("dpr-secret-name", "dpr-secret", `Default Docker Private Registry secret name`)
+	argGCRSecretName         = flags.String("gcr-secret-name", "gcr-secret", `Default GCR secret name`)
+	argGCRURL                = flags.String("gcr-url", "https://gcr.io", `Default GCR URL`)
+	argAWSRegion             = flags.String("aws-region", "us-east-1", `Default AWS region`)
+	argDPRPassword           = flags.String("dpr-password", "", "Docker Private Registry password")
+	argDPRServer             = flags.String("dpr-server", "", "Docker Private Registry server")
+	argDPRUser               = flags.String("dpr-user", "", "Docker Private Registry user")
+	argRefreshMinutes        = flags.Int("refresh-mins", 60, `Default time to wait before refreshing (60 minutes)`)
+	argSkipKubeSystem        = flags.Bool("skip-kube-system", true, `If true, will not attempt to set ImagePullSecrets on the kube-system namespace`)
+	argAWSAssumeRole         = flags.String("aws_assume_role", "", `If specified AWS will assume this role and use it to retrieve tokens`)
+	argTokenGenFxnRetries    = flags.Int("token-retries", defaultTokenGenRetries, `Default number of times to retry generating a secret token (3)`)
+	argTokenGenFxnRetryDelay = flags.Int("token-retry-delay", defaultTokenGenRetryDelay, `Default number of seconds to wait before retrying secret token generation (5 seconds)`)
 )
 
 var (
 	awsAccountIDs []string
+
+	// RetryCfg represents the currently-configured number of retries + retry delay
+	RetryCfg RetryConfig
 )
 
 type dockerJSON struct {
@@ -88,6 +98,12 @@ type controller struct {
 	ecrClient ecrInterface
 	gcrClient gcrInterface
 	dprClient dprInterface
+}
+
+// RetryConfig represents the number of retries + the retry delay for retrying an operation if it should fail
+type RetryConfig struct {
+	NumberOfRetries     int
+	RetryDelayInSeconds int
 }
 
 // Docker Private Registry interface
@@ -243,11 +259,13 @@ func generateSecretObj(tokens []AuthToken, isJSONCfg bool, secretName string) (*
 	return secret, nil
 }
 
+// AuthToken represents an Access Token and an Endpoint for a registry service
 type AuthToken struct {
 	AccessToken string
 	Endpoint    string
 }
 
+// SecretGenerator represents a token generation function for a registry service
 type SecretGenerator struct {
 	TokenGenFxn func() ([]AuthToken, error)
 	IsJSONCfg   bool
@@ -329,17 +347,35 @@ func (c *controller) generateSecrets() []*v1.Secret {
 	var secrets []*v1.Secret
 	secretGenerators := getSecretGenerators(c)
 
+	delayDuration := time.Duration(RetryCfg.RetryDelayInSeconds) * time.Second
+	maxTries := RetryCfg.NumberOfRetries + 1
 	for _, secretGenerator := range secretGenerators {
-		logrus.Printf("------------------ [%s] ----------------------\n", secretGenerator.SecretName)
+		logrus.Printf("------------------ [%s] ------------------\n", secretGenerator.SecretName)
 
-		newTokens, err := secretGenerator.TokenGenFxn()
-		if err != nil {
-			logrus.Printf("Error getting secret for provider %s. Skipping secret provider! [Err: %s]", secretGenerator.SecretName, err)
-			continue
+		var newTokens []AuthToken
+		tries := 0
+		for {
+			tries++
+			logrus.Printf("Getting secret; try #%d of %d", tries, maxTries)
+			tokens, err := secretGenerator.TokenGenFxn()
+			if err != nil {
+				if tries < maxTries {
+					logrus.Printf("Error getting secret for provider %s. Will try again after %d seconds. [Err: %s]", secretGenerator.SecretName, RetryCfg.RetryDelayInSeconds, err)
+					<-time.After(delayDuration)
+					continue
+				}
+				logrus.Printf("Error getting secret for provider %s. Tried %d time(s); will not try again until the next refresh cycle. [Err: %s]", secretGenerator.SecretName, tries, err)
+				break
+			} else {
+				logrus.Printf("Successfully got secret for provider %s after trying %d time(s)", secretGenerator.SecretName, tries)
+				newTokens = tokens
+				break
+			}
 		}
+
 		newSecret, err := generateSecretObj(newTokens, secretGenerator.IsJSONCfg, secretGenerator.SecretName)
 		if err != nil {
-			logrus.Printf("Error generating secret for provider %s. Skipping secret provider! [Err: %s]", secretGenerator.SecretName, err)
+			logrus.Printf("Error generating secret for provider %s. Skipping secret provider until the next refresh cycle! [Err: %s]", secretGenerator.SecretName, err)
 		} else {
 			secrets = append(secrets, newSecret)
 		}
@@ -356,6 +392,50 @@ func validateParams() {
 	dprServer := os.Getenv(dockerPrivateRegistryServerKey)
 	dprUser := os.Getenv(dockerPrivateRegistryUserKey)
 	gcrURLEnv := os.Getenv("gcrurl")
+
+	// initialize the retry configuration using command line values
+	RetryCfg = RetryConfig{
+		NumberOfRetries:     *argTokenGenFxnRetries,
+		RetryDelayInSeconds: *argTokenGenFxnRetryDelay,
+	}
+	// ensure command line values are valid
+	if RetryCfg.NumberOfRetries < 0 {
+		logrus.Errorf("Cannot use a negative value for the number of retries! Defaulting to %d", defaultTokenGenRetries)
+		RetryCfg.NumberOfRetries = defaultTokenGenRetries
+	}
+	if RetryCfg.RetryDelayInSeconds < 0 {
+		logrus.Errorf("Cannot use a negative value for the retry delay in seconds! Defaulting to %d", defaultTokenGenRetryDelay)
+		RetryCfg.RetryDelayInSeconds = defaultTokenGenRetryDelay
+	}
+	// look for overrides in environment variables and use them if they exist and are valid
+	tokenRetries, ok := os.LookupEnv(tokenGenRetriesKey)
+	if ok && len(tokenRetries) > 0 {
+		tokenRetriesInt, err := strconv.Atoi(tokenRetries)
+		if err != nil {
+			logrus.Errorf("Unable to parse value of environment variable %s! [Err: %s]", tokenGenRetriesKey, err)
+		} else {
+			if tokenRetriesInt < 0 {
+				logrus.Errorf("Cannot use a negative value for environment variable %s! Defaulting to %d", tokenGenRetriesKey, defaultTokenGenRetries)
+				RetryCfg.NumberOfRetries = defaultTokenGenRetries
+			} else {
+				RetryCfg.NumberOfRetries = tokenRetriesInt
+			}
+		}
+	}
+	tokenRetryDelay, ok := os.LookupEnv(tokenGenRetryDelayKey)
+	if ok && len(tokenRetryDelay) > 0 {
+		tokenRetryDelayInt, err := strconv.Atoi(tokenRetryDelay)
+		if err != nil {
+			logrus.Errorf("Unable to parse value of environment variable %s! [Err: %s]", tokenGenRetryDelayKey, err)
+		} else {
+			if tokenRetryDelayInt < 0 {
+				logrus.Errorf("Cannot use a negative value for environment variable %s! Defaulting to %d", tokenGenRetryDelayKey, defaultTokenGenRetryDelay)
+				RetryCfg.RetryDelayInSeconds = defaultTokenGenRetryDelay
+			} else {
+				RetryCfg.RetryDelayInSeconds = tokenRetryDelayInt
+			}
+		}
+	}
 
 	if len(awsRegionEnv) > 0 {
 		argAWSRegion = &awsRegionEnv
@@ -407,7 +487,10 @@ func handler(c *controller, ns *v1.Namespace) error {
 
 func main() {
 	log.Print("Starting up...")
-	flags.Parse(os.Args)
+	err := flags.Parse(os.Args)
+	if err != nil {
+		logrus.Fatalf("Could not parse command line arguments! [Err: %s]", err)
+	}
 
 	validateParams()
 
@@ -415,6 +498,8 @@ func main() {
 	log.Print("Using AWS Region: ", *argAWSRegion)
 	log.Print("Using AWS Assume Role: ", *argAWSAssumeRole)
 	log.Print("Refresh Interval (minutes): ", *argRefreshMinutes)
+	log.Print("Token Generation Retries: ", RetryCfg.NumberOfRetries)
+	log.Print("Token Generation Retry Delay (seconds): ", RetryCfg.RetryDelayInSeconds)
 
 	util, err := k8sutil.New(*argKubecfgFile, *argKubeMasterURL)
 

--- a/main_test.go
+++ b/main_test.go
@@ -28,9 +28,11 @@ func init() {
 	logrus.SetOutput(ioutil.Discard)
 	// don't use any retries during testing until we explicitly want to
 	RetryCfg = RetryConfig{
+		Type:                "simple",
 		NumberOfRetries:     0,
 		RetryDelayInSeconds: 1,
 	}
+	SetupRetryTimer()
 }
 
 type fakeKubeClient struct {
@@ -71,7 +73,7 @@ func (f *fakeSecrets) Create(secret *v1.Secret) (*v1.Secret, error) {
 	_, ok := f.store[secret.Name]
 
 	if ok {
-		return nil, fmt.Errorf("Secret %v already exists", secret.Name)
+		return nil, fmt.Errorf("secret %v already exists", secret.Name)
 	}
 
 	f.store[secret.Name] = secret
@@ -82,7 +84,7 @@ func (f *fakeSecrets) Update(secret *v1.Secret) (*v1.Secret, error) {
 	_, ok := f.store[secret.Name]
 
 	if !ok {
-		return nil, fmt.Errorf("Secret: %v not found", secret.Name)
+		return nil, fmt.Errorf("secret %v not found", secret.Name)
 	}
 
 	f.store[secret.Name] = secret
@@ -93,7 +95,7 @@ func (f *fakeSecrets) Get(name string) (*v1.Secret, error) {
 	secret, ok := f.store[name]
 
 	if !ok {
-		return nil, fmt.Errorf("Secret with name: %v not found", name)
+		return nil, fmt.Errorf("secret with name '%v' not found", name)
 	}
 
 	return secret, nil
@@ -113,7 +115,7 @@ func (f *fakeServiceAccounts) Get(name string) (*v1.ServiceAccount, error) {
 	serviceAccount, ok := f.store[name]
 
 	if !ok {
-		return nil, fmt.Errorf("Failed to find service account: %v", name)
+		return nil, fmt.Errorf("failed to find service account '%v'", name)
 	}
 
 	return serviceAccount, nil
@@ -123,7 +125,7 @@ func (f *fakeServiceAccounts) Update(serviceAccount *v1.ServiceAccount) (*v1.Ser
 	serviceAccount, ok := f.store[serviceAccount.Name]
 
 	if !ok {
-		return nil, fmt.Errorf("Service account: %v not found", serviceAccount.Name)
+		return nil, fmt.Errorf("service account '%v' not found", serviceAccount.Name)
 	}
 
 	f.store[serviceAccount.Name] = serviceAccount
@@ -142,7 +144,7 @@ func (f *fakeServiceAccounts) Delete(name string, options *v1.DeleteOptions) err
 	_, ok := f.store[name]
 
 	if !ok {
-		return fmt.Errorf("Service account: %v not found", name)
+		return fmt.Errorf("service account '%v' not found", name)
 	}
 
 	delete(f.store, name)
@@ -158,7 +160,7 @@ func (f *fakeServiceAccounts) List(opts v1.ListOptions) (*v1.ServiceAccountList,
 func (f *fakeServiceAccounts) Watch(opts v1.ListOptions) (watch.Interface, error) { return nil, nil }
 
 func (f *fakeNamespaces) List(opts v1.ListOptions) (*v1.NamespaceList, error) {
-	namespaces := []v1.Namespace{}
+	namespaces := make([]v1.Namespace, 0)
 
 	for _, v := range f.store {
 		namespaces = append(namespaces, v)
@@ -188,11 +190,11 @@ func (f *fakeEcrClient) GetAuthorizationToken(input *ecr.GetAuthorizationTokenIn
 	if len(input.RegistryIds) == 2 {
 		return &ecr.GetAuthorizationTokenOutput{
 			AuthorizationData: []*ecr.AuthorizationData{
-				&ecr.AuthorizationData{
+				{
 					AuthorizationToken: aws.String("fakeToken1"),
 					ProxyEndpoint:      aws.String("fakeEndpoint1"),
 				},
-				&ecr.AuthorizationData{
+				{
 					AuthorizationToken: aws.String("fakeToken2"),
 					ProxyEndpoint:      aws.String("fakeEndpoint2"),
 				},
@@ -201,7 +203,7 @@ func (f *fakeEcrClient) GetAuthorizationToken(input *ecr.GetAuthorizationTokenIn
 	}
 	return &ecr.GetAuthorizationTokenOutput{
 		AuthorizationData: []*ecr.AuthorizationData{
-			&ecr.AuthorizationData{
+			{
 				AuthorizationToken: aws.String("fakeToken"),
 				ProxyEndpoint:      aws.String("fakeEndpoint"),
 			},
@@ -261,55 +263,55 @@ func newKubeUtil() *k8sutil.K8sutilInterface {
 func newFakeKubeClient() k8sutil.KubeInterface {
 	return &fakeKubeClient{
 		secrets: map[string]*fakeSecrets{
-			"namespace1": &fakeSecrets{
+			"namespace1": {
 				store: map[string]*v1.Secret{},
 			},
-			"namespace2": &fakeSecrets{
+			"namespace2": {
 				store: map[string]*v1.Secret{},
 			},
-			"kube-system": &fakeSecrets{
+			"kube-system": {
 				store: map[string]*v1.Secret{},
 			},
 		},
 		namespaces: &fakeNamespaces{store: map[string]v1.Namespace{
-			"namespace1": v1.Namespace{
+			"namespace1": {
 				ObjectMeta: v1.ObjectMeta{
 					Name: "namespace1",
 				},
 			},
-			"namespace2": v1.Namespace{
+			"namespace2": {
 				ObjectMeta: v1.ObjectMeta{
 					Name: "namespace2",
 				},
 			},
-			"kube-system": v1.Namespace{
+			"kube-system": {
 				ObjectMeta: v1.ObjectMeta{
 					Name: "kube-system",
 				},
 			},
 		}},
 		serviceaccounts: map[string]*fakeServiceAccounts{
-			"namespace1": &fakeServiceAccounts{
+			"namespace1": {
 				store: map[string]*v1.ServiceAccount{
-					"default": &v1.ServiceAccount{
+					"default": {
 						ObjectMeta: v1.ObjectMeta{
 							Name: "default",
 						},
 					},
 				},
 			},
-			"namespace2": &fakeServiceAccounts{
+			"namespace2": {
 				store: map[string]*v1.ServiceAccount{
-					"default": &v1.ServiceAccount{
+					"default": {
 						ObjectMeta: v1.ObjectMeta{
 							Name: "default",
 						},
 					},
 				},
 			},
-			"kube-system": &fakeServiceAccounts{
+			"kube-system": {
 				store: map[string]*v1.ServiceAccount{
-					"default": &v1.ServiceAccount{
+					"default": {
 						ObjectMeta: v1.ObjectMeta{
 							Name: "default",
 						},
@@ -696,8 +698,8 @@ func TestDefaultAwsRegionFromArgs(t *testing.T) {
 func TestAwsRegionFromEnv(t *testing.T) {
 	expectedRegion := "us-steve-1"
 
-	os.Setenv("awsaccount", "12345678")
-	os.Setenv("awsregion", expectedRegion)
+	_ = os.Setenv("awsaccount", "12345678")
+	_ = os.Setenv("awsregion", expectedRegion)
 	validateParams()
 
 	assert.Equal(t, expectedRegion, *argAWSRegion)
@@ -706,7 +708,7 @@ func TestAwsRegionFromEnv(t *testing.T) {
 func TestGcrURLFromEnv(t *testing.T) {
 	expectedURL := "http://test.me"
 
-	os.Setenv("gcrurl", "http://test.me")
+	_ = os.Setenv("gcrurl", "http://test.me")
 	validateParams()
 
 	assert.Equal(t, expectedURL, *argGCRURL)
@@ -734,7 +736,7 @@ func TestPassingGcrPassingEcrStillSucceeds(t *testing.T) {
 	process(t, &c)
 }
 
-func TestControllerGenerateSecretsRetryOnError(t *testing.T) {
+func TestControllerGenerateSecretsSimpleRetryOnError(t *testing.T) {
 	// enable log output for this test
 	log.SetOutput(os.Stdout)
 	logrus.SetOutput(os.Stdout)
@@ -744,9 +746,36 @@ func TestControllerGenerateSecretsRetryOnError(t *testing.T) {
 		logrus.SetOutput(ioutil.Discard)
 	}()
 	RetryCfg = RetryConfig{
+		Type:                "simple",
 		NumberOfRetries:     2,
 		RetryDelayInSeconds: 1,
 	}
+	SetupRetryTimer()
+	util := newKubeUtil()
+	ecrClient := newFakeFailingEcrClient()
+	gcrClient := newFakeFailingGcrClient()
+	dprClient := newFakeFailingDprClient()
+	awsAccountIDs = []string{""}
+	c := controller{util, ecrClient, gcrClient, dprClient}
+
+	process(t, &c)
+}
+
+func TestControllerGenerateSecretsExponentialRetryOnError(t *testing.T) {
+	// enable log output for this test
+	log.SetOutput(os.Stdout)
+	logrus.SetOutput(os.Stdout)
+	// disable log output when the test has completed
+	defer func() {
+		log.SetOutput(ioutil.Discard)
+		logrus.SetOutput(ioutil.Discard)
+	}()
+	RetryCfg = RetryConfig{
+		Type:                "exponential",
+		NumberOfRetries:     3,
+		RetryDelayInSeconds: 1,
+	}
+	SetupRetryTimer()
 	util := newKubeUtil()
 	ecrClient := newFakeFailingEcrClient()
 	gcrClient := newFakeFailingGcrClient()

--- a/vendor/github.com/cenkalti/backoff/.gitignore
+++ b/vendor/github.com/cenkalti/backoff/.gitignore
@@ -1,0 +1,22 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe

--- a/vendor/github.com/cenkalti/backoff/.travis.yml
+++ b/vendor/github.com/cenkalti/backoff/.travis.yml
@@ -1,0 +1,10 @@
+language: go
+go:
+  - 1.7
+  - 1.x
+  - tip
+before_install:
+  - go get github.com/mattn/goveralls
+  - go get golang.org/x/tools/cmd/cover
+script:
+  - $HOME/gopath/bin/goveralls -service=travis-ci

--- a/vendor/github.com/cenkalti/backoff/LICENSE
+++ b/vendor/github.com/cenkalti/backoff/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Cenk Altı
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/cenkalti/backoff/README.md
+++ b/vendor/github.com/cenkalti/backoff/README.md
@@ -1,0 +1,30 @@
+# Exponential Backoff [![GoDoc][godoc image]][godoc] [![Build Status][travis image]][travis] [![Coverage Status][coveralls image]][coveralls]
+
+This is a Go port of the exponential backoff algorithm from [Google's HTTP Client Library for Java][google-http-java-client].
+
+[Exponential backoff][exponential backoff wiki]
+is an algorithm that uses feedback to multiplicatively decrease the rate of some process,
+in order to gradually find an acceptable rate.
+The retries exponentially increase and stop increasing when a certain threshold is met.
+
+## Usage
+
+See https://godoc.org/github.com/cenkalti/backoff#pkg-examples
+
+## Contributing
+
+* I would like to keep this library as small as possible.
+* Please don't send a PR without opening an issue and discussing it first.
+* If proposed change is not a common use case, I will probably not accept it.
+
+[godoc]: https://godoc.org/github.com/cenkalti/backoff
+[godoc image]: https://godoc.org/github.com/cenkalti/backoff?status.png
+[travis]: https://travis-ci.org/cenkalti/backoff
+[travis image]: https://travis-ci.org/cenkalti/backoff.png?branch=master
+[coveralls]: https://coveralls.io/github/cenkalti/backoff?branch=master
+[coveralls image]: https://coveralls.io/repos/github/cenkalti/backoff/badge.svg?branch=master
+
+[google-http-java-client]: https://github.com/google/google-http-java-client/blob/da1aa993e90285ec18579f1553339b00e19b3ab5/google-http-client/src/main/java/com/google/api/client/util/ExponentialBackOff.java
+[exponential backoff wiki]: http://en.wikipedia.org/wiki/Exponential_backoff
+
+[advanced example]: https://godoc.org/github.com/cenkalti/backoff#example_

--- a/vendor/github.com/cenkalti/backoff/backoff.go
+++ b/vendor/github.com/cenkalti/backoff/backoff.go
@@ -1,0 +1,66 @@
+// Package backoff implements backoff algorithms for retrying operations.
+//
+// Use Retry function for retrying operations that may fail.
+// If Retry does not meet your needs,
+// copy/paste the function into your project and modify as you wish.
+//
+// There is also Ticker type similar to time.Ticker.
+// You can use it if you need to work with channels.
+//
+// See Examples section below for usage examples.
+package backoff
+
+import "time"
+
+// BackOff is a backoff policy for retrying an operation.
+type BackOff interface {
+	// NextBackOff returns the duration to wait before retrying the operation,
+	// or backoff. Stop to indicate that no more retries should be made.
+	//
+	// Example usage:
+	//
+	// 	duration := backoff.NextBackOff();
+	// 	if (duration == backoff.Stop) {
+	// 		// Do not retry operation.
+	// 	} else {
+	// 		// Sleep for duration and retry operation.
+	// 	}
+	//
+	NextBackOff() time.Duration
+
+	// Reset to initial state.
+	Reset()
+}
+
+// Stop indicates that no more retries should be made for use in NextBackOff().
+const Stop time.Duration = -1
+
+// ZeroBackOff is a fixed backoff policy whose backoff time is always zero,
+// meaning that the operation is retried immediately without waiting, indefinitely.
+type ZeroBackOff struct{}
+
+func (b *ZeroBackOff) Reset() {}
+
+func (b *ZeroBackOff) NextBackOff() time.Duration { return 0 }
+
+// StopBackOff is a fixed backoff policy that always returns backoff.Stop for
+// NextBackOff(), meaning that the operation should never be retried.
+type StopBackOff struct{}
+
+func (b *StopBackOff) Reset() {}
+
+func (b *StopBackOff) NextBackOff() time.Duration { return Stop }
+
+// ConstantBackOff is a backoff policy that always returns the same backoff delay.
+// This is in contrast to an exponential backoff policy,
+// which returns a delay that grows longer as you call NextBackOff() over and over again.
+type ConstantBackOff struct {
+	Interval time.Duration
+}
+
+func (b *ConstantBackOff) Reset()                     {}
+func (b *ConstantBackOff) NextBackOff() time.Duration { return b.Interval }
+
+func NewConstantBackOff(d time.Duration) *ConstantBackOff {
+	return &ConstantBackOff{Interval: d}
+}

--- a/vendor/github.com/cenkalti/backoff/backoff_test.go
+++ b/vendor/github.com/cenkalti/backoff/backoff_test.go
@@ -1,0 +1,27 @@
+package backoff
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNextBackOffMillis(t *testing.T) {
+	subtestNextBackOff(t, 0, new(ZeroBackOff))
+	subtestNextBackOff(t, Stop, new(StopBackOff))
+}
+
+func subtestNextBackOff(t *testing.T, expectedValue time.Duration, backOffPolicy BackOff) {
+	for i := 0; i < 10; i++ {
+		next := backOffPolicy.NextBackOff()
+		if next != expectedValue {
+			t.Errorf("got: %d expected: %d", next, expectedValue)
+		}
+	}
+}
+
+func TestConstantBackOff(t *testing.T) {
+	backoff := NewConstantBackOff(time.Second)
+	if backoff.NextBackOff() != time.Second {
+		t.Error("invalid interval")
+	}
+}

--- a/vendor/github.com/cenkalti/backoff/context.go
+++ b/vendor/github.com/cenkalti/backoff/context.go
@@ -1,0 +1,63 @@
+package backoff
+
+import (
+	"context"
+	"time"
+)
+
+// BackOffContext is a backoff policy that stops retrying after the context
+// is canceled.
+type BackOffContext interface {
+	BackOff
+	Context() context.Context
+}
+
+type backOffContext struct {
+	BackOff
+	ctx context.Context
+}
+
+// WithContext returns a BackOffContext with context ctx
+//
+// ctx must not be nil
+func WithContext(b BackOff, ctx context.Context) BackOffContext {
+	if ctx == nil {
+		panic("nil context")
+	}
+
+	if b, ok := b.(*backOffContext); ok {
+		return &backOffContext{
+			BackOff: b.BackOff,
+			ctx:     ctx,
+		}
+	}
+
+	return &backOffContext{
+		BackOff: b,
+		ctx:     ctx,
+	}
+}
+
+func ensureContext(b BackOff) BackOffContext {
+	if cb, ok := b.(BackOffContext); ok {
+		return cb
+	}
+	return WithContext(b, context.Background())
+}
+
+func (b *backOffContext) Context() context.Context {
+	return b.ctx
+}
+
+func (b *backOffContext) NextBackOff() time.Duration {
+	select {
+	case <-b.ctx.Done():
+		return Stop
+	default:
+	}
+	next := b.BackOff.NextBackOff()
+	if deadline, ok := b.ctx.Deadline(); ok && deadline.Sub(time.Now()) < next {
+		return Stop
+	}
+	return next
+}

--- a/vendor/github.com/cenkalti/backoff/context_test.go
+++ b/vendor/github.com/cenkalti/backoff/context_test.go
@@ -1,0 +1,25 @@
+package backoff
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestContext(t *testing.T) {
+	b := NewConstantBackOff(time.Millisecond)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cb := WithContext(b, ctx)
+
+	if cb.Context() != ctx {
+		t.Error("invalid context")
+	}
+
+	cancel()
+
+	if cb.NextBackOff() != Stop {
+		t.Error("invalid next back off")
+	}
+}

--- a/vendor/github.com/cenkalti/backoff/example_test.go
+++ b/vendor/github.com/cenkalti/backoff/example_test.go
@@ -1,0 +1,72 @@
+package backoff
+
+import (
+	"context"
+	"log"
+)
+
+func ExampleRetry() {
+	// An operation that may fail.
+	operation := func() error {
+		return nil // or an error
+	}
+
+	err := Retry(operation, NewExponentialBackOff())
+	if err != nil {
+		// Handle error.
+		return
+	}
+
+	// Operation is successful.
+}
+
+func ExampleRetryContext() {
+	// A context
+	ctx := context.Background()
+
+	// An operation that may fail.
+	operation := func() error {
+		return nil // or an error
+	}
+
+	b := WithContext(NewExponentialBackOff(), ctx)
+
+	err := Retry(operation, b)
+	if err != nil {
+		// Handle error.
+		return
+	}
+
+	// Operation is successful.
+}
+
+func ExampleTicker() {
+	// An operation that may fail.
+	operation := func() error {
+		return nil // or an error
+	}
+
+	ticker := NewTicker(NewExponentialBackOff())
+
+	var err error
+
+	// Ticks will continue to arrive when the previous operation is still running,
+	// so operations that take a while to fail could run in quick succession.
+	for _ = range ticker.C {
+		if err = operation(); err != nil {
+			log.Println(err, "will retry...")
+			continue
+		}
+
+		ticker.Stop()
+		break
+	}
+
+	if err != nil {
+		// Operation has failed.
+		return
+	}
+
+	// Operation is successful.
+	return
+}

--- a/vendor/github.com/cenkalti/backoff/exponential.go
+++ b/vendor/github.com/cenkalti/backoff/exponential.go
@@ -1,0 +1,153 @@
+package backoff
+
+import (
+	"math/rand"
+	"time"
+)
+
+/*
+ExponentialBackOff is a backoff implementation that increases the backoff
+period for each retry attempt using a randomization function that grows exponentially.
+
+NextBackOff() is calculated using the following formula:
+
+ randomized interval =
+     RetryInterval * (random value in range [1 - RandomizationFactor, 1 + RandomizationFactor])
+
+In other words NextBackOff() will range between the randomization factor
+percentage below and above the retry interval.
+
+For example, given the following parameters:
+
+ RetryInterval = 2
+ RandomizationFactor = 0.5
+ Multiplier = 2
+
+the actual backoff period used in the next retry attempt will range between 1 and 3 seconds,
+multiplied by the exponential, that is, between 2 and 6 seconds.
+
+Note: MaxInterval caps the RetryInterval and not the randomized interval.
+
+If the time elapsed since an ExponentialBackOff instance is created goes past the
+MaxElapsedTime, then the method NextBackOff() starts returning backoff.Stop.
+
+The elapsed time can be reset by calling Reset().
+
+Example: Given the following default arguments, for 10 tries the sequence will be,
+and assuming we go over the MaxElapsedTime on the 10th try:
+
+ Request #  RetryInterval (seconds)  Randomized Interval (seconds)
+
+  1          0.5                     [0.25,   0.75]
+  2          0.75                    [0.375,  1.125]
+  3          1.125                   [0.562,  1.687]
+  4          1.687                   [0.8435, 2.53]
+  5          2.53                    [1.265,  3.795]
+  6          3.795                   [1.897,  5.692]
+  7          5.692                   [2.846,  8.538]
+  8          8.538                   [4.269, 12.807]
+  9         12.807                   [6.403, 19.210]
+ 10         19.210                   backoff.Stop
+
+Note: Implementation is not thread-safe.
+*/
+type ExponentialBackOff struct {
+	InitialInterval     time.Duration
+	RandomizationFactor float64
+	Multiplier          float64
+	MaxInterval         time.Duration
+	// After MaxElapsedTime the ExponentialBackOff stops.
+	// It never stops if MaxElapsedTime == 0.
+	MaxElapsedTime time.Duration
+	Clock          Clock
+
+	currentInterval time.Duration
+	startTime       time.Time
+}
+
+// Clock is an interface that returns current time for BackOff.
+type Clock interface {
+	Now() time.Time
+}
+
+// Default values for ExponentialBackOff.
+const (
+	DefaultInitialInterval     = 500 * time.Millisecond
+	DefaultRandomizationFactor = 0.5
+	DefaultMultiplier          = 1.5
+	DefaultMaxInterval         = 60 * time.Second
+	DefaultMaxElapsedTime      = 15 * time.Minute
+)
+
+// NewExponentialBackOff creates an instance of ExponentialBackOff using default values.
+func NewExponentialBackOff() *ExponentialBackOff {
+	b := &ExponentialBackOff{
+		InitialInterval:     DefaultInitialInterval,
+		RandomizationFactor: DefaultRandomizationFactor,
+		Multiplier:          DefaultMultiplier,
+		MaxInterval:         DefaultMaxInterval,
+		MaxElapsedTime:      DefaultMaxElapsedTime,
+		Clock:               SystemClock,
+	}
+	b.Reset()
+	return b
+}
+
+type systemClock struct{}
+
+func (t systemClock) Now() time.Time {
+	return time.Now()
+}
+
+// SystemClock implements Clock interface that uses time.Now().
+var SystemClock = systemClock{}
+
+// Reset the interval back to the initial retry interval and restarts the timer.
+func (b *ExponentialBackOff) Reset() {
+	b.currentInterval = b.InitialInterval
+	b.startTime = b.Clock.Now()
+}
+
+// NextBackOff calculates the next backoff interval using the formula:
+// 	Randomized interval = RetryInterval +/- (RandomizationFactor * RetryInterval)
+func (b *ExponentialBackOff) NextBackOff() time.Duration {
+	// Make sure we have not gone over the maximum elapsed time.
+	if b.MaxElapsedTime != 0 && b.GetElapsedTime() > b.MaxElapsedTime {
+		return Stop
+	}
+	defer b.incrementCurrentInterval()
+	return getRandomValueFromInterval(b.RandomizationFactor, rand.Float64(), b.currentInterval)
+}
+
+// GetElapsedTime returns the elapsed time since an ExponentialBackOff instance
+// is created and is reset when Reset() is called.
+//
+// The elapsed time is computed using time.Now().UnixNano(). It is
+// safe to call even while the backoff policy is used by a running
+// ticker.
+func (b *ExponentialBackOff) GetElapsedTime() time.Duration {
+	return b.Clock.Now().Sub(b.startTime)
+}
+
+// Increments the current interval by multiplying it with the multiplier.
+func (b *ExponentialBackOff) incrementCurrentInterval() {
+	// Check for overflow, if overflow is detected set the current interval to the max interval.
+	if float64(b.currentInterval) >= float64(b.MaxInterval)/b.Multiplier {
+		b.currentInterval = b.MaxInterval
+	} else {
+		b.currentInterval = time.Duration(float64(b.currentInterval) * b.Multiplier)
+	}
+}
+
+// Returns a random value from the following interval:
+// 	[randomizationFactor * currentInterval, randomizationFactor * currentInterval].
+func getRandomValueFromInterval(randomizationFactor, random float64, currentInterval time.Duration) time.Duration {
+	var delta = randomizationFactor * float64(currentInterval)
+	var minInterval = float64(currentInterval) - delta
+	var maxInterval = float64(currentInterval) + delta
+
+	// Get a random value from the range [minInterval, maxInterval].
+	// The formula used below has a +1 because if the minInterval is 1 and the maxInterval is 3 then
+	// we want a 33% chance for selecting either 1, 2 or 3.
+	return time.Duration(minInterval + (random * (maxInterval - minInterval + 1)))
+}

--- a/vendor/github.com/cenkalti/backoff/exponential_test.go
+++ b/vendor/github.com/cenkalti/backoff/exponential_test.go
@@ -1,0 +1,108 @@
+package backoff
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+func TestBackOff(t *testing.T) {
+	var (
+		testInitialInterval     = 500 * time.Millisecond
+		testRandomizationFactor = 0.1
+		testMultiplier          = 2.0
+		testMaxInterval         = 5 * time.Second
+		testMaxElapsedTime      = 15 * time.Minute
+	)
+
+	exp := NewExponentialBackOff()
+	exp.InitialInterval = testInitialInterval
+	exp.RandomizationFactor = testRandomizationFactor
+	exp.Multiplier = testMultiplier
+	exp.MaxInterval = testMaxInterval
+	exp.MaxElapsedTime = testMaxElapsedTime
+	exp.Reset()
+
+	var expectedResults = []time.Duration{500, 1000, 2000, 4000, 5000, 5000, 5000, 5000, 5000, 5000}
+	for i, d := range expectedResults {
+		expectedResults[i] = d * time.Millisecond
+	}
+
+	for _, expected := range expectedResults {
+		assertEquals(t, expected, exp.currentInterval)
+		// Assert that the next backoff falls in the expected range.
+		var minInterval = expected - time.Duration(testRandomizationFactor*float64(expected))
+		var maxInterval = expected + time.Duration(testRandomizationFactor*float64(expected))
+		var actualInterval = exp.NextBackOff()
+		if !(minInterval <= actualInterval && actualInterval <= maxInterval) {
+			t.Error("error")
+		}
+	}
+}
+
+func TestGetRandomizedInterval(t *testing.T) {
+	// 33% chance of being 1.
+	assertEquals(t, 1, getRandomValueFromInterval(0.5, 0, 2))
+	assertEquals(t, 1, getRandomValueFromInterval(0.5, 0.33, 2))
+	// 33% chance of being 2.
+	assertEquals(t, 2, getRandomValueFromInterval(0.5, 0.34, 2))
+	assertEquals(t, 2, getRandomValueFromInterval(0.5, 0.66, 2))
+	// 33% chance of being 3.
+	assertEquals(t, 3, getRandomValueFromInterval(0.5, 0.67, 2))
+	assertEquals(t, 3, getRandomValueFromInterval(0.5, 0.99, 2))
+}
+
+type TestClock struct {
+	i     time.Duration
+	start time.Time
+}
+
+func (c *TestClock) Now() time.Time {
+	t := c.start.Add(c.i)
+	c.i += time.Second
+	return t
+}
+
+func TestGetElapsedTime(t *testing.T) {
+	var exp = NewExponentialBackOff()
+	exp.Clock = &TestClock{}
+	exp.Reset()
+
+	var elapsedTime = exp.GetElapsedTime()
+	if elapsedTime != time.Second {
+		t.Errorf("elapsedTime=%d", elapsedTime)
+	}
+}
+
+func TestMaxElapsedTime(t *testing.T) {
+	var exp = NewExponentialBackOff()
+	exp.Clock = &TestClock{start: time.Time{}.Add(10000 * time.Second)}
+	// Change the currentElapsedTime to be 0 ensuring that the elapsed time will be greater
+	// than the max elapsed time.
+	exp.startTime = time.Time{}
+	assertEquals(t, Stop, exp.NextBackOff())
+}
+
+func TestBackOffOverflow(t *testing.T) {
+	var (
+		testInitialInterval time.Duration = math.MaxInt64 / 2
+		testMaxInterval     time.Duration = math.MaxInt64
+		testMultiplier                    = 2.1
+	)
+
+	exp := NewExponentialBackOff()
+	exp.InitialInterval = testInitialInterval
+	exp.Multiplier = testMultiplier
+	exp.MaxInterval = testMaxInterval
+	exp.Reset()
+
+	exp.NextBackOff()
+	// Assert that when an overflow is possible the current varerval   time.Duration    is set to the max varerval   time.Duration   .
+	assertEquals(t, testMaxInterval, exp.currentInterval)
+}
+
+func assertEquals(t *testing.T, expected, value time.Duration) {
+	if expected != value {
+		t.Errorf("got: %d, expected: %d", value, expected)
+	}
+}

--- a/vendor/github.com/cenkalti/backoff/retry.go
+++ b/vendor/github.com/cenkalti/backoff/retry.go
@@ -1,0 +1,82 @@
+package backoff
+
+import "time"
+
+// An Operation is executing by Retry() or RetryNotify().
+// The operation will be retried using a backoff policy if it returns an error.
+type Operation func() error
+
+// Notify is a notify-on-error function. It receives an operation error and
+// backoff delay if the operation failed (with an error).
+//
+// NOTE that if the backoff policy stated to stop retrying,
+// the notify function isn't called.
+type Notify func(error, time.Duration)
+
+// Retry the operation o until it does not return error or BackOff stops.
+// o is guaranteed to be run at least once.
+//
+// If o returns a *PermanentError, the operation is not retried, and the
+// wrapped error is returned.
+//
+// Retry sleeps the goroutine for the duration returned by BackOff after a
+// failed operation returns.
+func Retry(o Operation, b BackOff) error { return RetryNotify(o, b, nil) }
+
+// RetryNotify calls notify function with the error and wait duration
+// for each failed attempt before sleep.
+func RetryNotify(operation Operation, b BackOff, notify Notify) error {
+	var err error
+	var next time.Duration
+	var t *time.Timer
+
+	cb := ensureContext(b)
+
+	b.Reset()
+	for {
+		if err = operation(); err == nil {
+			return nil
+		}
+
+		if permanent, ok := err.(*PermanentError); ok {
+			return permanent.Err
+		}
+
+		if next = cb.NextBackOff(); next == Stop {
+			return err
+		}
+
+		if notify != nil {
+			notify(err, next)
+		}
+
+		if t == nil {
+			t = time.NewTimer(next)
+			defer t.Stop()
+		} else {
+			t.Reset(next)
+		}
+
+		select {
+		case <-cb.Context().Done():
+			return err
+		case <-t.C:
+		}
+	}
+}
+
+// PermanentError signals that the operation should not be retried.
+type PermanentError struct {
+	Err error
+}
+
+func (e *PermanentError) Error() string {
+	return e.Err.Error()
+}
+
+// Permanent wraps the given err in a *PermanentError.
+func Permanent(err error) *PermanentError {
+	return &PermanentError{
+		Err: err,
+	}
+}

--- a/vendor/github.com/cenkalti/backoff/retry_test.go
+++ b/vendor/github.com/cenkalti/backoff/retry_test.go
@@ -1,0 +1,98 @@
+package backoff
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"testing"
+	"time"
+)
+
+func TestRetry(t *testing.T) {
+	const successOn = 3
+	var i = 0
+
+	// This function is successful on "successOn" calls.
+	f := func() error {
+		i++
+		log.Printf("function is called %d. time\n", i)
+
+		if i == successOn {
+			log.Println("OK")
+			return nil
+		}
+
+		log.Println("error")
+		return errors.New("error")
+	}
+
+	err := Retry(f, NewExponentialBackOff())
+	if err != nil {
+		t.Errorf("unexpected error: %s", err.Error())
+	}
+	if i != successOn {
+		t.Errorf("invalid number of retries: %d", i)
+	}
+}
+
+func TestRetryContext(t *testing.T) {
+	var cancelOn = 3
+	var i = 0
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// This function cancels context on "cancelOn" calls.
+	f := func() error {
+		i++
+		log.Printf("function is called %d. time\n", i)
+
+		// cancelling the context in the operation function is not a typical
+		// use-case, however it allows to get predictable test results.
+		if i == cancelOn {
+			cancel()
+		}
+
+		log.Println("error")
+		return fmt.Errorf("error (%d)", i)
+	}
+
+	err := Retry(f, WithContext(NewConstantBackOff(time.Millisecond), ctx))
+	if err == nil {
+		t.Errorf("error is unexpectedly nil")
+	}
+	if err.Error() != "error (3)" {
+		t.Errorf("unexpected error: %s", err.Error())
+	}
+	if i != cancelOn {
+		t.Errorf("invalid number of retries: %d", i)
+	}
+}
+
+func TestRetryPermenent(t *testing.T) {
+	const permanentOn = 3
+	var i = 0
+
+	// This function fails permanently after permanentOn tries
+	f := func() error {
+		i++
+		log.Printf("function is called %d. time\n", i)
+
+		if i == permanentOn {
+			log.Println("permanent error")
+			return Permanent(errors.New("permanent error"))
+		}
+
+		log.Println("error")
+		return errors.New("error")
+	}
+
+	err := Retry(f, NewExponentialBackOff())
+	if err == nil || err.Error() != "permanent error" {
+		t.Errorf("unexpected error: %s", err)
+	}
+	if i != permanentOn {
+		t.Errorf("invalid number of retries: %d", i)
+	}
+}

--- a/vendor/github.com/cenkalti/backoff/ticker.go
+++ b/vendor/github.com/cenkalti/backoff/ticker.go
@@ -1,0 +1,82 @@
+package backoff
+
+import (
+	"sync"
+	"time"
+)
+
+// Ticker holds a channel that delivers `ticks' of a clock at times reported by a BackOff.
+//
+// Ticks will continue to arrive when the previous operation is still running,
+// so operations that take a while to fail could run in quick succession.
+type Ticker struct {
+	C        <-chan time.Time
+	c        chan time.Time
+	b        BackOffContext
+	stop     chan struct{}
+	stopOnce sync.Once
+}
+
+// NewTicker returns a new Ticker containing a channel that will send
+// the time at times specified by the BackOff argument. Ticker is
+// guaranteed to tick at least once.  The channel is closed when Stop
+// method is called or BackOff stops. It is not safe to manipulate the
+// provided backoff policy (notably calling NextBackOff or Reset)
+// while the ticker is running.
+func NewTicker(b BackOff) *Ticker {
+	c := make(chan time.Time)
+	t := &Ticker{
+		C:    c,
+		c:    c,
+		b:    ensureContext(b),
+		stop: make(chan struct{}),
+	}
+	t.b.Reset()
+	go t.run()
+	return t
+}
+
+// Stop turns off a ticker. After Stop, no more ticks will be sent.
+func (t *Ticker) Stop() {
+	t.stopOnce.Do(func() { close(t.stop) })
+}
+
+func (t *Ticker) run() {
+	c := t.c
+	defer close(c)
+
+	// Ticker is guaranteed to tick at least once.
+	afterC := t.send(time.Now())
+
+	for {
+		if afterC == nil {
+			return
+		}
+
+		select {
+		case tick := <-afterC:
+			afterC = t.send(tick)
+		case <-t.stop:
+			t.c = nil // Prevent future ticks from being sent to the channel.
+			return
+		case <-t.b.Context().Done():
+			return
+		}
+	}
+}
+
+func (t *Ticker) send(tick time.Time) <-chan time.Time {
+	select {
+	case t.c <- tick:
+	case <-t.stop:
+		return nil
+	}
+
+	next := t.b.NextBackOff()
+	if next == Stop {
+		t.Stop()
+		return nil
+	}
+
+	return time.After(next)
+}

--- a/vendor/github.com/cenkalti/backoff/ticker_test.go
+++ b/vendor/github.com/cenkalti/backoff/ticker_test.go
@@ -1,0 +1,97 @@
+package backoff
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"testing"
+	"time"
+)
+
+func TestTicker(t *testing.T) {
+	const successOn = 3
+	var i = 0
+
+	// This function is successful on "successOn" calls.
+	f := func() error {
+		i++
+		log.Printf("function is called %d. time\n", i)
+
+		if i == successOn {
+			log.Println("OK")
+			return nil
+		}
+
+		log.Println("error")
+		return errors.New("error")
+	}
+
+	b := NewExponentialBackOff()
+	ticker := NewTicker(b)
+	elapsed := b.GetElapsedTime()
+	if elapsed > time.Second {
+		t.Errorf("elapsed time too large: %v", elapsed)
+	}
+
+	var err error
+	for _ = range ticker.C {
+		if err = f(); err != nil {
+			t.Log(err)
+			continue
+		}
+
+		break
+	}
+	if err != nil {
+		t.Errorf("unexpected error: %s", err.Error())
+	}
+	if i != successOn {
+		t.Errorf("invalid number of retries: %d", i)
+	}
+}
+
+func TestTickerContext(t *testing.T) {
+	const cancelOn = 3
+	var i = 0
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// This function cancels context on "cancelOn" calls.
+	f := func() error {
+		i++
+		log.Printf("function is called %d. time\n", i)
+
+		// cancelling the context in the operation function is not a typical
+		// use-case, however it allows to get predictable test results.
+		if i == cancelOn {
+			cancel()
+		}
+
+		log.Println("error")
+		return fmt.Errorf("error (%d)", i)
+	}
+
+	b := WithContext(NewConstantBackOff(time.Millisecond), ctx)
+	ticker := NewTicker(b)
+
+	var err error
+	for _ = range ticker.C {
+		if err = f(); err != nil {
+			t.Log(err)
+			continue
+		}
+
+		break
+	}
+	if err == nil {
+		t.Errorf("error is unexpectedly nil")
+	}
+	if err.Error() != "error (3)" {
+		t.Errorf("unexpected error: %s", err.Error())
+	}
+	if i != cancelOn {
+		t.Errorf("invalid number of retries: %d", i)
+	}
+}

--- a/vendor/github.com/cenkalti/backoff/tries.go
+++ b/vendor/github.com/cenkalti/backoff/tries.go
@@ -1,0 +1,35 @@
+package backoff
+
+import "time"
+
+/*
+WithMaxRetries creates a wrapper around another BackOff, which will
+return Stop if NextBackOff() has been called too many times since
+the last time Reset() was called
+
+Note: Implementation is not thread-safe.
+*/
+func WithMaxRetries(b BackOff, max uint64) BackOff {
+	return &backOffTries{delegate: b, maxTries: max}
+}
+
+type backOffTries struct {
+	delegate BackOff
+	maxTries uint64
+	numTries uint64
+}
+
+func (b *backOffTries) NextBackOff() time.Duration {
+	if b.maxTries > 0 {
+		if b.maxTries <= b.numTries {
+			return Stop
+		}
+		b.numTries++
+	}
+	return b.delegate.NextBackOff()
+}
+
+func (b *backOffTries) Reset() {
+	b.numTries = 0
+	b.delegate.Reset()
+}

--- a/vendor/github.com/cenkalti/backoff/tries_test.go
+++ b/vendor/github.com/cenkalti/backoff/tries_test.go
@@ -1,0 +1,55 @@
+package backoff
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+)
+
+func TestMaxTriesHappy(t *testing.T) {
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	max := 17 + r.Intn(13)
+	bo := WithMaxRetries(&ZeroBackOff{}, uint64(max))
+
+	// Load up the tries count, but reset should clear the record
+	for ix := 0; ix < max/2; ix++ {
+		bo.NextBackOff()
+	}
+	bo.Reset()
+
+	// Now fill the tries count all the way up
+	for ix := 0; ix < max; ix++ {
+		d := bo.NextBackOff()
+		if d == Stop {
+			t.Errorf("returned Stop on try %d", ix)
+		}
+	}
+
+	// We have now called the BackOff max number of times, we expect
+	// the next result to be Stop, even if we try it multiple times
+	for ix := 0; ix < 7; ix++ {
+		d := bo.NextBackOff()
+		if d != Stop {
+			t.Error("invalid next back off")
+		}
+	}
+
+	// Reset makes it all work again
+	bo.Reset()
+	d := bo.NextBackOff()
+	if d == Stop {
+		t.Error("returned Stop after reset")
+	}
+
+}
+
+func TestMaxTriesZero(t *testing.T) {
+	// It might not make sense, but its okay to send a zero
+	bo := WithMaxRetries(&ZeroBackOff{}, uint64(0))
+	for ix := 0; ix < 11; ix++ {
+		d := bo.NextBackOff()
+		if d == Stop {
+			t.Errorf("returned Stop on try %d", ix)
+		}
+	}
+}


### PR DESCRIPTION
It is possible for `registry-creds` to encounter an error (e.g. network error) when fetching an authorization token for a repository. This results in pods not getting updated with the appropriate secret until the next refresh cycle, which is 60 minutes later by default. For environments where it is not trivial to change the `registry-creds` refresh time (e.g. minikube), a simple retry mechanism can mitigate the issue.

To that end I have implemented a retry mechanism in `controller.generateSecrets()` which retries token generation a set number of times upon failure with a configurable delay between successive attempts. I've chosen 3 retry attempts with a 5 second delay before each retry as the default values. Both values are configurable via CLI parameters and via environment variables, with the latter overriding the former. `README.md` has been updated to reflect the environment variables and their default values.