### PR TITLE
Replace ReplicationController with Deployment

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,20 +1,17 @@
-apiVersion: v1
-kind: ReplicationController
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   name: registry-creds
   namespace: kube-system
-  labels:
-    version: v1.6
 spec:
   replicas: 1
   selector:
-    name: registry-creds
-    version: v1.9
+    matchLabels:
+      name: registry-creds
   template:
     metadata:
       labels:
         name: registry-creds
-        version: v1.9
     spec:
       containers:
       - image: upmcenterprises/registry-creds:1.9


### PR DESCRIPTION
As the official k8s docs state:

> Note: A Deployment that configures a ReplicaSet is now the recommended way to set up replication.

https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/

Fixes #76 