### PR TITLE
Add missing env vars for Azure container registry

### DIFF
--- a/k8s/replicationController.yaml
+++ b/k8s/replicationController.yaml
@@ -61,6 +61,21 @@ spec:
               secretKeyRef:
                 name: registry-creds-dpr
                 key: DOCKER_PRIVATE_REGISTRY_USER
+          - name: ACR_URL
+            valueFrom:
+              secretKeyRef:
+                name: registry-creds-acr
+                key: ACR_URL
+          - name: ACR_CLIENT_ID
+            valueFrom:
+              secretKeyRef:
+                name: registry-creds-acr
+                key: ACR_CLIENT_ID
+          - name: ACR_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: registry-creds-acr
+                key: ACR_PASSWORD
         volumeMounts:
         - name: gcr-creds
           mountPath: "/root/.config/gcloud"


### PR DESCRIPTION
After some more testing I realized I forgot to include this change in my original PR that enabled Azure container registry. Sorry about that! 