### PR TITLE
Use latest Alpine version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.4
+FROM alpine:3.13
 MAINTAINER Steve Sloka <steve@stevesloka.com>
 
 RUN apk add --update ca-certificates && \


### PR DESCRIPTION
Update from unsupported Alpine 3.4 to keep vulnerability scanners happy