### PR TITLE
Include exclude namespaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 registry-creds
 .vscode/
+.history/

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # MAINTAINER: Steve Sloka <steve@stevesloka.com>
 # If you update this image please bump the tag value before pushing.
 
-TAG = 1.10
+TAG = 1.11
 PREFIX = upmcenterprises
 
 BIN = registry-creds

--- a/Makefile
+++ b/Makefile
@@ -46,9 +46,4 @@ clean:
 
 .PHONY: test
 test: clean
-	# $(GO_BINARY) test -v $(go list ./... | grep -v vendor)
-	$(GO_BINARY) test -v -run TestProcessOnce
-
-.PHONY: test-all
-test-all: clean
 	$(GO_BINARY) test -v $(go list ./... | grep -v vendor)

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ PREFIX = upmcenterprises
 BIN = registry-creds
 
 GO111MODULE=off
+GO_BINARY=go
 
 # docker build arguments for internal proxy
 ifneq ($(http_proxy),)
@@ -27,7 +28,7 @@ all: container
 
 .PHONY: build
 build: main.go
-	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -a -installsuffix cgo -o $(BIN) --ldflags '-w' $<
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 $(GO_BINARY) build -a -installsuffix cgo -o $(BIN) --ldflags '-w' $<
 
 .PHONY: container
 container: build
@@ -45,4 +46,4 @@ clean:
 
 .PHONY: test
 test: clean
-	go test -v $(go list ./... | grep -v vendor)
+	$(GO_BINARY) test -v $(go list ./... | grep -v vendor)

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ PREFIX = upmcenterprises
 BIN = registry-creds
 
 GO111MODULE=off
+GO_BINARY=go1.8
 
 # docker build arguments for internal proxy
 ifneq ($(http_proxy),)
@@ -27,7 +28,7 @@ all: container
 
 .PHONY: build
 build: main.go
-	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -a -installsuffix cgo -o $(BIN) --ldflags '-w' $<
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 $(GO_BINARY) build -a -installsuffix cgo -o $(BIN) --ldflags '-w' $<
 
 .PHONY: container
 container: build
@@ -45,4 +46,9 @@ clean:
 
 .PHONY: test
 test: clean
-	go test -v $(go list ./... | grep -v vendor)
+	# $(GO_BINARY) test -v $(go list ./... | grep -v vendor)
+	$(GO_BINARY) test -v -run TestProcessOnce
+
+.PHONY: test-all
+test-all: clean
+	$(GO_BINARY) test -v $(go list ./... | grep -v vendor)

--- a/main.go
+++ b/main.go
@@ -512,6 +512,7 @@ func validateParams() {
 	// initialize namespace inclusions and exclusions
 	if len(*argIncludeNamespaces) > 0 && len(*argExcludeNamespaces) > 0 {
 		logrus.Errorf("Ignoring 'exclude-namespaces', as 'include-namespaces' is provided.")
+		*argExcludeNamespaces = ""
 		excludeNamespaces = []string{}
 	}
 
@@ -635,7 +636,7 @@ func validateParams() {
 }
 
 func handler(c *controller, ns *v1.Namespace) error {
-	logrus.Info("Handling namespace watch event for %s", ns.GetName())
+	logrus.Infof("Handling namespace watch event for %s", ns.GetName())
 
 	// process exclusions first, if set
 	for _, e := range excludeNamespaces {

--- a/main_test.go
+++ b/main_test.go
@@ -377,11 +377,25 @@ func newFakeFailingACRClient() *fakeFailingACRClient {
 	return &fakeFailingACRClient{}
 }
 
-func process(t *testing.T, c *controller) {
-	namespaces, _ := c.k8sutil.Kclient.Namespaces().List(v1.ListOptions{})
-	for _, ns := range namespaces.Items {
-		err := handler(c, &ns)
-		assert.Nil(t, err)
+func process(t *testing.T, c *controller, namespaces ...string) {
+	if len(namespaces) == 0 {
+		namespaces = []string{"namespace1", "namespace2"}
+	}
+	all_nss, _ := c.k8sutil.Kclient.Namespaces().List(v1.ListOptions{})
+	for _, ns := range all_nss.Items {
+
+		ok_to_process := false
+		for _, select_ns := range namespaces {
+			if select_ns == ns.GetName() {
+				ok_to_process = true
+				break;
+			}
+		}
+
+		if ok_to_process {
+			err := handler(c, &ns)
+			assert.Nil(t, err)
+		}
 	}
 }
 
@@ -443,9 +457,13 @@ func assertAllSecretsPresent(t *testing.T, secrets []v1.LocalObjectReference) {
 	assertSecretPresent(t, secrets, *argACRSecretName)
 }
 
-func assertAllExpectedSecrets(t *testing.T, c *controller) {
+func assertAllExpectedSecrets(t *testing.T, c *controller, namespaces ...string) {
+	if len(namespaces) == 0 {
+		namespaces = []string{"namespace1", "namespace2"}
+	}
+
 	// Test GCR
-	for _, ns := range []string{"namespace1", "namespace2"} {
+	for _, ns := range namespaces {
 		secret, err := c.k8sutil.GetSecret(ns, *argGCRSecretName)
 		assert.Nil(t, err)
 		assert.Equal(t, *argGCRSecretName, secret.Name)
@@ -459,7 +477,7 @@ func assertAllExpectedSecrets(t *testing.T, c *controller) {
 	assert.NotNil(t, err)
 
 	// Test AWS
-	for _, ns := range []string{"namespace1", "namespace2"} {
+	for _, ns := range namespaces {
 		secret, err := c.k8sutil.GetSecret(ns, *argAWSSecretName)
 		assert.Nil(t, err)
 		assert.Equal(t, *argAWSSecretName, secret.Name)
@@ -471,7 +489,7 @@ func assertAllExpectedSecrets(t *testing.T, c *controller) {
 	assert.NotNil(t, err)
 
 	// Test Azure Container Registry support
-	for _, ns := range []string{"namespace1", "namespace2"} {
+	for _, ns := range namespaces {
 		secret, err := c.k8sutil.GetSecret(ns, *argACRSecretName)
 		assert.Nil(t, err)
 		assert.Equal(t, *argACRSecretName, secret.Name)
@@ -483,17 +501,19 @@ func assertAllExpectedSecrets(t *testing.T, c *controller) {
 	assert.NotNil(t, err)
 
 	// Verify that all expected secrets have been created in all namespaces
-	serviceAccount, err := c.k8sutil.GetServiceAccount("namespace1", "default")
+	for _, ns := range namespaces {
+		serviceAccount, err := c.k8sutil.GetServiceAccount(ns, "default")
 	assert.Nil(t, err)
 	assertAllSecretsPresent(t, serviceAccount.ImagePullSecrets)
-
-	serviceAccount, err = c.k8sutil.GetServiceAccount("namespace2", "default")
-	assert.Nil(t, err)
-	assertAllSecretsPresent(t, serviceAccount.ImagePullSecrets)
+	}
 }
 
-func assertExpectedSecretNumber(t *testing.T, c *controller, n int) {
-	for _, ns := range []string{"namespace1", "namespace2"} {
+func assertExpectedSecretNumber(t *testing.T, c *controller, n int, namespaces ...string) {
+	if len(namespaces) == 0 {
+		namespaces = []string{"namespace1", "namespace2"}
+}
+
+	for _, ns := range namespaces {
 		serviceAccount, err := c.k8sutil.GetServiceAccount(ns, "default")
 		assert.Nil(t, err)
 		assert.Exactly(t, n, len(serviceAccount.ImagePullSecrets))
@@ -514,7 +534,92 @@ func TestProcessOnce(t *testing.T) {
 	assertExpectedSecretNumber(t, c, 4)
 }
 
+func TestProcessOnceIncludeNamespacesBaseCase(t *testing.T) {
+	*argGCRURL = "fakeEndpoint"
+	*argIncludeNamespaces = ""
+	awsAccountIDs = []string{""}
+	c := newFakeController()
+	validateParams()
+
+	process(t, c)
+
+	assertAllExpectedSecrets(t, c)
+
+	// Verify that secrets have not been created twice
+	assertExpectedSecretNumber(t, c, 4)
+}
+
+func TestProcessOnceIncludeAllIndividualNamespaces(t *testing.T) {
+	*argGCRURL = "fakeEndpoint"
+	*argIncludeNamespaces = "namespace1,namespace2"
+	awsAccountIDs = []string{""}
+	c := newFakeController()
+	validateParams()
+
+	process(t, c)
+
+	assertAllExpectedSecrets(t, c)
+
+	// Verify that secrets have not been created twice
+	assertExpectedSecretNumber(t, c, 4)
+}
+
+func TestProcessOnceIncludeOneNamespace(t *testing.T) {
+	*argGCRURL = "fakeEndpoint"
+	*argIncludeNamespaces = "namespace1"
+	awsAccountIDs = []string{""}
+	c := newFakeController()
+	validateParams()
+
+	process(t, c, "namespace1")
+
+	assertAllExpectedSecrets(t, c, "namespace1")
+
+	// Verify that secrets have not been created twice
+	assertExpectedSecretNumber(t, c, 4, "namespace1")
+	// Verify that kube-system namespace is excluded
+	assertExpectedSecretNumber(t, c, 0, "kube-system")
+}
+
+func TestProcessWithBothInclusionAndExclusionListsForNamespaces(t *testing.T) {
+	*argGCRURL = "fakeEndpoint"
+	*argIncludeNamespaces = "namespace1,namespace2"
+	*argExcludeNamespaces = "namespace1"
+	awsAccountIDs = []string{""}
+	c := newFakeController()
+	validateParams()
+
+	process(t, c)
+
+	assertAllExpectedSecrets(t, c)
+
+	// Verify that secrets have not been created twice
+	assertExpectedSecretNumber(t, c, 4)
+}
+
+func TestProcessWithOnlyExclusionListsForNamespaces(t *testing.T) {
+	*argGCRURL = "fakeEndpoint"
+	*argIncludeNamespaces = "" // reset to all namespaces
+	*argExcludeNamespaces = "namespace1"
+	awsAccountIDs = []string{""}
+	c := newFakeController()
+	validateParams()
+
+	process(t, c)
+
+	assertAllExpectedSecrets(t, c, "namespace2")
+
+	// Verify that secrets have not been created twice
+	assertExpectedSecretNumber(t, c, 4, "namespace2")
+	// Verify no secrets exist for excluded namespace
+	assertExpectedSecretNumber(t, c, 0, "namespace1")
+	// Verify that kube-system namespace is excluded
+	assertExpectedSecretNumber(t, c, 0, "kube-system")
+}
+
 func TestProcessTwice(t *testing.T) {
+	*argIncludeNamespaces = "" // all namespaces
+	*argExcludeNamespaces = "" // exclude none
 	*argGCRURL = "fakeEndpoint"
 	c := newFakeController()
 	validateParams()

--- a/main_test.go
+++ b/main_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ecr"
 	"github.com/stretchr/testify/assert"
-	"github.com/upmc-enterprises/registry-creds/k8sutil"
+	"github.com/ede-n/registry-creds/k8sutil"
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 	coreType "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -504,15 +504,20 @@ func TestProcessOnce(t *testing.T) {
 	*argGCRURL = "fakeEndpoint"
 	awsAccountIDs = []string{""}
 	c := newFakeController()
+	validateParams()
 
 	process(t, c)
 
 	assertAllExpectedSecrets(t, c)
+
+	// Verify that secrets have not been created twice
+	assertExpectedSecretNumber(t, c, 4)
 }
 
 func TestProcessTwice(t *testing.T) {
 	*argGCRURL = "fakeEndpoint"
 	c := newFakeController()
+	validateParams()
 
 	process(t, c)
 	// test processing twice for idempotency
@@ -527,6 +532,7 @@ func TestProcessTwice(t *testing.T) {
 func TestProcessWithExistingSecrets(t *testing.T) {
 	*argGCRURL = "fakeEndpoint"
 	c := newFakeController()
+	validateParams()
 
 	secretGCR := &v1.Secret{
 		ObjectMeta: v1.ObjectMeta{
@@ -599,6 +605,7 @@ func TestProcessWithExistingSecrets(t *testing.T) {
 
 func TestProcessWithExistingImagePullSecrets(t *testing.T) {
 	c := newFakeController()
+	validateParams()
 
 	for _, ns := range []string{"namespace1", "namespace2"} {
 		serviceAccount, err := c.k8sutil.GetServiceAccount(ns, "default")

--- a/main_test.go
+++ b/main_test.go
@@ -377,25 +377,11 @@ func newFakeFailingACRClient() *fakeFailingACRClient {
 	return &fakeFailingACRClient{}
 }
 
-func process(t *testing.T, c *controller, namespaces ...string) {
-	if len(namespaces) == 0 {
-		namespaces = []string{"namespace1", "namespace2"}
-	}
+func process(t *testing.T, c *controller) {
 	all_nss, _ := c.k8sutil.Kclient.Namespaces().List(v1.ListOptions{})
 	for _, ns := range all_nss.Items {
-
-		ok_to_process := false
-		for _, select_ns := range namespaces {
-			if select_ns == ns.GetName() {
-				ok_to_process = true
-				break;
-			}
-		}
-
-		if ok_to_process {
-			err := handler(c, &ns)
-			assert.Nil(t, err)
-		}
+		err := handler(c, &ns)
+		assert.Nil(t, err)
 	}
 }
 
@@ -571,7 +557,7 @@ func TestProcessOnceIncludeOneNamespace(t *testing.T) {
 	c := newFakeController()
 	validateParams()
 
-	process(t, c, "namespace1")
+	process(t, c)
 
 	assertAllExpectedSecrets(t, c, "namespace1")
 


### PR DESCRIPTION
Introduces two new arguments 

* `--include-namespaces`: a subset of namespaces to process, if empty processes all namespaces.
* `--exclude-namespaces`: a subset of namespaces to exclude from processing. 

In this implementation I do not except both the arguments to be provided for a given invocation. If both the arguments are provided, only inclusion list is used for processing, exclusion list is ignored.

